### PR TITLE
20231005 basic structures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,10 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+openssl = "^0.10.57"
+tracing = "^0.1.37"
+serde = { version = "^1.0", features = ["derive"] }
+
+[dev-dependencies]
+tracing-subscriber = "^0.3.17"
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,13 +16,13 @@
 #![deny(clippy::manual_let_else)]
 #![allow(clippy::unreachable)]
 
-mod soft;
+pub mod soft;
 // mod tpm;
 // future goal ... once I can afford one ...
 // mod yubihsm;
 
 #[derive(Debug, Clone)]
-enum HSMError {
+enum HsmError {
     Aes256GcmConfig,
     Aes256GcmEncrypt,
     Aes256GcmDecrypt,
@@ -32,30 +32,30 @@ enum HSMError {
     Entropy,
 }
 
-trait HSM {
+trait Hsm {
     type MachineKey;
     type LoadableMachineKey;
 
     type HmacKey;
     type LoadableHmacKey;
 
-    fn machine_key_create(&mut self) -> Result<Self::LoadableMachineKey, HSMError>;
+    fn machine_key_create(&mut self) -> Result<Self::LoadableMachineKey, HsmError>;
 
     fn machine_key_load(
         &mut self,
         exported_key: &Self::LoadableMachineKey,
-    ) -> Result<Self::MachineKey, HSMError>;
+    ) -> Result<Self::MachineKey, HsmError>;
 
     fn hmac_key_create(&mut self, mk: &Self::MachineKey)
-        -> Result<Self::LoadableHmacKey, HSMError>;
+        -> Result<Self::LoadableHmacKey, HsmError>;
 
     fn hmac_key_load(
         &mut self,
         mk: &Self::MachineKey,
         exported_key: &Self::LoadableHmacKey,
-    ) -> Result<Self::HmacKey, HSMError>;
+    ) -> Result<Self::HmacKey, HsmError>;
 
-    fn hmac(&mut self, hk: &Self::HmacKey, input: &[u8]) -> Result<Vec<u8>, HSMError>;
+    fn hmac(&mut self, hk: &Self::HmacKey, input: &[u8]) -> Result<Vec<u8>, HsmError>;
 }
 
 #[cfg(test)]
@@ -68,8 +68,8 @@ mod tests {
     #[test]
     fn basic_interaction_hw_bound_key() {
         let _ = tracing_subscriber::fmt::try_init();
-        // Create the HSM.
-        let mut hsm = SoftHSM::new();
+        // Create the Hsm.
+        let mut hsm = SoftHsm::new();
 
         // Request a new machine-key-context. This key "owns" anything
         // created underneath it.
@@ -99,13 +99,13 @@ mod tests {
             .hmac(&hmac_key, &[0, 1, 2, 3])
             .expect("Unable to perform hmac");
 
-        // destroy the HSM
+        // destroy the Hsm
         drop(hmac_key);
         drop(machine_key);
         drop(hsm);
 
-        // Make a new HSM context.
-        let mut hsm = SoftHSM::new();
+        // Make a new Hsm context.
+        let mut hsm = SoftHsm::new();
 
         // Load the contexts.
         let machine_key = hsm

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,128 @@
-pub fn add(left: usize, right: usize) -> usize {
-    left + right
+#![deny(warnings)]
+#![warn(unused_extern_crates)]
+// Enable some groups of clippy lints.
+#![deny(clippy::suspicious)]
+#![deny(clippy::perf)]
+// Specific lints to enforce.
+#![deny(clippy::todo)]
+#![deny(clippy::unimplemented)]
+#![deny(clippy::unwrap_used)]
+#![deny(clippy::expect_used)]
+#![deny(clippy::panic)]
+#![deny(clippy::await_holding_lock)]
+#![deny(clippy::needless_pass_by_value)]
+#![deny(clippy::trivially_copy_pass_by_ref)]
+#![deny(clippy::disallowed_types)]
+#![deny(clippy::manual_let_else)]
+#![allow(clippy::unreachable)]
+
+mod soft;
+// mod tpm;
+// future goal ... once I can afford one ...
+// mod yubihsm;
+
+#[derive(Debug, Clone)]
+enum HSMError {
+    Aes256GcmConfig,
+    Aes256GcmEncrypt,
+    Aes256GcmDecrypt,
+    HmacKey,
+    HmacSign,
+
+    Entropy,
+}
+
+trait HSM {
+    type MachineKey;
+    type LoadableMachineKey;
+
+    type HmacKey;
+    type LoadableHmacKey;
+
+    fn machine_key_create(&mut self) -> Result<Self::LoadableMachineKey, HSMError>;
+
+    fn machine_key_load(
+        &mut self,
+        exported_key: &Self::LoadableMachineKey,
+    ) -> Result<Self::MachineKey, HSMError>;
+
+    fn hmac_key_create(&mut self, mk: &Self::MachineKey)
+        -> Result<Self::LoadableHmacKey, HSMError>;
+
+    fn hmac_key_load(
+        &mut self,
+        mk: &Self::MachineKey,
+        exported_key: &Self::LoadableHmacKey,
+    ) -> Result<Self::HmacKey, HSMError>;
+
+    fn hmac(&mut self, hk: &Self::HmacKey, input: &[u8]) -> Result<Vec<u8>, HSMError>;
 }
 
 #[cfg(test)]
 mod tests {
+    use super::soft::*;
     use super::*;
 
+    use tracing::trace;
+
     #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
+    fn basic_interaction_hw_bound_key() {
+        let _ = tracing_subscriber::fmt::try_init();
+        // Create the HSM.
+        let mut hsm = SoftHSM::new();
+
+        // Request a new machine-key-context. This key "owns" anything
+        // created underneath it.
+        let loadable_machine_key = hsm
+            .machine_key_create()
+            .expect("Unable to create new machine key");
+
+        trace!(?loadable_machine_key);
+
+        let machine_key = hsm
+            .machine_key_load(&loadable_machine_key)
+            .expect("Unable to load machine key");
+
+        // from that ctx, create a hmac key.
+        let loadable_hmac_key = hsm
+            .hmac_key_create(&machine_key)
+            .expect("Unable to create new hmac key");
+
+        trace!(?loadable_hmac_key);
+
+        let hmac_key = hsm
+            .hmac_key_load(&machine_key, &loadable_hmac_key)
+            .expect("Unable to load hmac key");
+
+        // do a hmac.
+        let output_1 = hsm
+            .hmac(&hmac_key, &[0, 1, 2, 3])
+            .expect("Unable to perform hmac");
+
+        // destroy the HSM
+        drop(hmac_key);
+        drop(machine_key);
+        drop(hsm);
+
+        // Make a new HSM context.
+        let mut hsm = SoftHSM::new();
+
+        // Load the contexts.
+        let machine_key = hsm
+            .machine_key_load(&loadable_machine_key)
+            .expect("Unable to load machine key");
+
+        // Load the keys.
+        let hmac_key = hsm
+            .hmac_key_load(&machine_key, &loadable_hmac_key)
+            .expect("Unable to load hmac key");
+
+        // Do another hmac
+        let output_2 = hsm
+            .hmac(&hmac_key, &[0, 1, 2, 3])
+            .expect("Unable to perform hmac");
+
+        // It should be the same.
+        assert_eq!(output_1, output_2);
     }
 }


### PR DESCRIPTION
This adds the basic structures that I want to achieve here. It creates a Hsm trait which has certain operations, and the ability to create keys related to a context. This matches the behaviour of Tpm's that we intend to wrap next. 

In addition the immediate benefit of this is that we have the ability to aes-256-gcm encrypt hmac keys at rest. 

