### PR TITLE
zeroize everything, add key derivation, enforce auth to tpm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ openssl = "^0.10.57"
 tracing = "^0.1.37"
 serde = { version = "^1.0", features = ["derive"] }
 tss-esapi = { version = "^7.3.0", optional = true }
+zeroize = "1.6.0"
+argon2 = { version = "0.5.2", features = ["alloc"] }
 
 [dev-dependencies]
 tracing-subscriber = "^0.3.17"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,12 @@
 #![deny(clippy::manual_let_else)]
 #![allow(clippy::unreachable)]
 
+use std::str::FromStr;
+use tracing::error;
+use zeroize::Zeroizing;
+
+use argon2::MIN_SALT_LEN;
+
 pub mod soft;
 
 #[cfg(feature = "tpm")]
@@ -23,8 +29,61 @@ pub mod tpm;
 // future goal ... once I can afford one ...
 // mod yubihsm;
 
+pub enum AuthValue {
+    Key256Bit { auth_key: Zeroizing<[u8; 32]> },
+}
+
+impl AuthValue {
+    pub fn new_random() -> Result<Self, HsmError> {
+        let mut auth_key = Zeroizing::new([0; 32]);
+        openssl::rand::rand_bytes(auth_key.as_mut()).map_err(|ossl_err| {
+            error!(?ossl_err);
+            HsmError::Entropy
+        })?;
+
+        Ok(AuthValue::Key256Bit { auth_key })
+    }
+}
+
+impl FromStr for AuthValue {
+    type Err = HsmError;
+
+    fn from_str(cleartext: &str) -> Result<Self, Self::Err> {
+        use argon2::{Algorithm, Argon2, Params, Version};
+
+        let mut auth_key = Zeroizing::new([0; 32]);
+
+        // This can't be changed else it will break key derivation for users.
+        let argon2id_params =
+            Params::new(32_768, 4, 1, Some(auth_key.as_ref().len())).map_err(|argon_err| {
+                error!(?argon_err);
+                HsmError::AuthValueDerivation
+            })?;
+
+        let argon = Argon2::new(Algorithm::Argon2id, Version::V0x13, argon2id_params);
+
+        // Want at least 8 bytes salt, 16 bytes pw input.
+        if cleartext.len() < 24 {
+            return Err(HsmError::AuthValueTooShort);
+        }
+
+        let (salt, key) = cleartext.as_bytes().split_at(MIN_SALT_LEN);
+
+        argon
+            .hash_password_into(key, salt, auth_key.as_mut())
+            .map_err(|argon_err| {
+                error!(?argon_err);
+                HsmError::AuthValueDerivation
+            })?;
+
+        Ok(AuthValue::Key256Bit { auth_key })
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum HsmError {
+    AuthValueTooShort,
+    AuthValueDerivation,
     Aes256GcmConfig,
     Aes256GcmEncrypt,
     Aes256GcmDecrypt,
@@ -36,6 +95,7 @@ pub enum HsmError {
     TpmPrimaryPublicBuilderInvalid,
     TpmPrimaryCreate,
     TpmEntropy,
+    TpmAuthValueInvalid,
 
     TpmMachineKeyObjectAttributesInvalid,
     TpmMachineKeyBuilderInvalid,
@@ -60,10 +120,14 @@ trait Hsm {
     type HmacKey;
     type LoadableHmacKey;
 
-    fn machine_key_create(&mut self) -> Result<Self::LoadableMachineKey, HsmError>;
+    fn machine_key_create(
+        &mut self,
+        auth_value: &AuthValue,
+    ) -> Result<Self::LoadableMachineKey, HsmError>;
 
     fn machine_key_load(
         &mut self,
+        auth_value: &AuthValue,
         exported_key: &Self::LoadableMachineKey,
     ) -> Result<Self::MachineKey, HsmError>;
 


### PR DESCRIPTION
Fixes #9 and Fixes #10 - This adds an "auth_value" which acts as the password to unlock the HSM tree. This can in future be passed in from services like systemd. 

## Checklist

- [ x ] This pr contains no AI generated code
- [ x ] cargo fmt has been run
- [ x ] cargo clippy has been run and there's no issues
- [ x ] cargo test has been run and passes
