### PR TITLE
Store identity certs/keys in the HSM

### DIFF
--- a/src/soft.rs
+++ b/src/soft.rs
@@ -233,7 +233,7 @@ impl HsmIdentity for SoftHsm {
 
                 let der = eckey
                     .private_key_to_der()
-                    .map(|bytes| Zeroizing::new(bytes))
+                    .map(Zeroizing::new)
                     .map_err(|ossl_err| {
                         error!(?ossl_err);
                         HsmError::EcKeyPrivateToDer
@@ -263,7 +263,7 @@ impl HsmIdentity for SoftHsm {
 
                 let der = rsa
                     .private_key_to_der()
-                    .map(|bytes| Zeroizing::new(bytes))
+                    .map(Zeroizing::new)
                     .map_err(|ossl_err| {
                         error!(?ossl_err);
                         HsmError::RsaPrivateToDer
@@ -381,7 +381,7 @@ impl HsmIdentity for SoftHsm {
         let mut signer = match key {
             SoftIdentityKey::Ecdsa256 { pkey, x509: _ }
             | SoftIdentityKey::Rsa2048 { pkey, x509: _ } => {
-                Signer::new(MessageDigest::sha256(), &pkey).map_err(|ossl_err| {
+                Signer::new(MessageDigest::sha256(), pkey).map_err(|ossl_err| {
                     error!(?ossl_err);
                     HsmError::IdentityKeyInvalidForSigning
                 })?

--- a/src/soft.rs
+++ b/src/soft.rs
@@ -1,11 +1,15 @@
-use crate::{AuthValue, Hsm, HsmError};
+use crate::{AuthValue, Hsm, HsmError, HsmIdentity, KeyAlgorithm};
 use zeroize::Zeroizing;
 
+use openssl::ec::{EcGroup, EcKey};
 use openssl::hash::MessageDigest;
+use openssl::nid::Nid;
 use openssl::pkey::{PKey, Private};
 use openssl::rand::rand_bytes;
+use openssl::rsa::Rsa;
 use openssl::sign::Signer;
 use openssl::symm::{Cipher, Crypter, Mode};
+use openssl::x509::X509;
 
 use serde::{Deserialize, Serialize};
 use tracing::error;
@@ -54,6 +58,33 @@ pub enum SoftLoadableHmacKey {
         key: Vec<u8>,
         tag: [u8; 16],
         iv: [u8; 16],
+    },
+}
+
+pub enum SoftIdentityKey {
+    Rsa2048 {
+        pkey: PKey<Private>,
+        x509: Option<X509>,
+    },
+    Ecdsa256 {
+        pkey: PKey<Private>,
+        x509: Option<X509>,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum SoftLoadableIdentityKey {
+    Rsa2048V1 {
+        key: Vec<u8>,
+        tag: [u8; 16],
+        iv: [u8; 16],
+        x509: Option<Vec<u8>>,
+    },
+    Ecdsa256V1 {
+        key: Vec<u8>,
+        tag: [u8; 16],
+        iv: [u8; 16],
+        x509: Option<Vec<u8>>,
     },
 }
 
@@ -178,6 +209,192 @@ impl Hsm for SoftHsm {
     }
 }
 
+impl HsmIdentity for SoftHsm {
+    type IdentityKey = SoftIdentityKey;
+    type LoadableIdentityKey = SoftLoadableIdentityKey;
+
+    fn identity_key_create(
+        &mut self,
+        mk: &Self::MachineKey,
+        algorithm: KeyAlgorithm,
+    ) -> Result<Self::LoadableIdentityKey, HsmError> {
+        match algorithm {
+            KeyAlgorithm::Ecdsa256 => {
+                let ecgroup =
+                    EcGroup::from_curve_name(Nid::X9_62_PRIME256V1).map_err(|ossl_err| {
+                        error!(?ossl_err);
+                        HsmError::EcGroup
+                    })?;
+
+                let eckey = EcKey::generate(&ecgroup).map_err(|ossl_err| {
+                    error!(?ossl_err);
+                    HsmError::EcKeyGenerate
+                })?;
+
+                let der = eckey
+                    .private_key_to_der()
+                    .map(|bytes| Zeroizing::new(bytes))
+                    .map_err(|ossl_err| {
+                        error!(?ossl_err);
+                        HsmError::EcKeyPrivateToDer
+                    })?;
+
+                let mut iv = [0; 16];
+                rand_bytes(&mut iv).map_err(|ossl_err| {
+                    error!(?ossl_err);
+                    HsmError::Entropy
+                })?;
+
+                let (key, tag) = match mk {
+                    SoftMachineKey::Aes256Gcm { key } => {
+                        aes_256_gcm_encrypt(der.as_ref(), key.as_ref(), &iv)?
+                    }
+                };
+
+                let x509 = None;
+
+                Ok(SoftLoadableIdentityKey::Ecdsa256V1 { key, tag, iv, x509 })
+            }
+            KeyAlgorithm::Rsa2048 => {
+                let rsa = Rsa::generate(2048).map_err(|ossl_err| {
+                    error!(?ossl_err);
+                    HsmError::RsaGenerate
+                })?;
+
+                let der = rsa
+                    .private_key_to_der()
+                    .map(|bytes| Zeroizing::new(bytes))
+                    .map_err(|ossl_err| {
+                        error!(?ossl_err);
+                        HsmError::RsaPrivateToDer
+                    })?;
+
+                let mut iv = [0; 16];
+                rand_bytes(&mut iv).map_err(|ossl_err| {
+                    error!(?ossl_err);
+                    HsmError::Entropy
+                })?;
+
+                let (key, tag) = match mk {
+                    SoftMachineKey::Aes256Gcm { key } => {
+                        aes_256_gcm_encrypt(der.as_ref(), key.as_ref(), &iv)?
+                    }
+                };
+
+                let x509 = None;
+
+                Ok(SoftLoadableIdentityKey::Rsa2048V1 { key, tag, iv, x509 })
+            }
+        }
+    }
+
+    fn identity_key_load(
+        &mut self,
+        mk: &Self::MachineKey,
+        loadable_key: &Self::LoadableIdentityKey,
+    ) -> Result<Self::IdentityKey, HsmError> {
+        match (mk, loadable_key) {
+            (
+                SoftMachineKey::Aes256Gcm { key: mk_key },
+                SoftLoadableIdentityKey::Ecdsa256V1 { key, tag, iv, x509 },
+            ) => {
+                let key_der = aes_256_gcm_decrypt(key, tag, mk_key.as_ref(), iv)?;
+
+                let eckey = EcKey::private_key_from_der(key_der.as_ref()).map_err(|ossl_err| {
+                    error!(?ossl_err);
+                    HsmError::EcKeyFromDer
+                })?;
+
+                let pkey = PKey::from_ec_key(eckey).map_err(|ossl_err| {
+                    error!(?ossl_err);
+                    HsmError::EcKeyToPrivateKey
+                })?;
+
+                let x509 = match x509 {
+                    Some(der) => X509::from_der(der).map(Some).map_err(|ossl_err| {
+                        error!(?ossl_err);
+                        HsmError::X509FromDer
+                    })?,
+                    None => None,
+                };
+
+                Ok(SoftIdentityKey::Ecdsa256 { pkey, x509 })
+            }
+            (
+                SoftMachineKey::Aes256Gcm { key: mk_key },
+                SoftLoadableIdentityKey::Rsa2048V1 { key, tag, iv, x509 },
+            ) => {
+                let key_der = aes_256_gcm_decrypt(key, tag, mk_key.as_ref(), iv)?;
+
+                let eckey = Rsa::private_key_from_der(key_der.as_ref()).map_err(|ossl_err| {
+                    error!(?ossl_err);
+                    HsmError::RsaKeyFromDer
+                })?;
+
+                let pkey = PKey::from_rsa(eckey).map_err(|ossl_err| {
+                    error!(?ossl_err);
+                    HsmError::RsaToPrivateKey
+                })?;
+
+                let x509 = match x509 {
+                    Some(der) => X509::from_der(der).map(Some).map_err(|ossl_err| {
+                        error!(?ossl_err);
+                        HsmError::X509FromDer
+                    })?,
+                    None => None,
+                };
+
+                Ok(SoftIdentityKey::Rsa2048 { pkey, x509 })
+            }
+        }
+    }
+
+    fn identity_key_public_as_der(&mut self, key: &Self::IdentityKey) -> Result<Vec<u8>, HsmError> {
+        match key {
+            SoftIdentityKey::Ecdsa256 { pkey, x509: _ }
+            | SoftIdentityKey::Rsa2048 { pkey, x509: _ } => {
+                pkey.public_key_to_der().map_err(|ossl_err| {
+                    error!(?ossl_err);
+                    HsmError::IdentityKeyPublicToDer
+                })
+            }
+        }
+    }
+
+    fn identity_key_public_as_pem(&mut self, key: &Self::IdentityKey) -> Result<Vec<u8>, HsmError> {
+        match key {
+            SoftIdentityKey::Ecdsa256 { pkey, x509: _ }
+            | SoftIdentityKey::Rsa2048 { pkey, x509: _ } => {
+                pkey.public_key_to_pem().map_err(|ossl_err| {
+                    error!(?ossl_err);
+                    HsmError::IdentityKeyPublicToPem
+                })
+            }
+        }
+    }
+
+    fn identity_key_sign(
+        &mut self,
+        key: &Self::IdentityKey,
+        input: &[u8],
+    ) -> Result<Vec<u8>, HsmError> {
+        let mut signer = match key {
+            SoftIdentityKey::Ecdsa256 { pkey, x509: _ }
+            | SoftIdentityKey::Rsa2048 { pkey, x509: _ } => {
+                Signer::new(MessageDigest::sha256(), &pkey).map_err(|ossl_err| {
+                    error!(?ossl_err);
+                    HsmError::IdentityKeyInvalidForSigning
+                })?
+            }
+        };
+
+        signer.sign_oneshot_to_vec(input).map_err(|ossl_err| {
+            error!(?ossl_err);
+            HsmError::IdentityKeySignature
+        })
+    }
+}
+
 fn aes_256_gcm_encrypt(
     input: &[u8],
     key: &[u8],
@@ -258,8 +475,11 @@ fn aes_256_gcm_decrypt(
 
 #[cfg(test)]
 mod tests {
-    use super::{aes_256_gcm_decrypt, aes_256_gcm_encrypt, SoftHsm};
-    use crate::{AuthValue, Hsm};
+    use super::{aes_256_gcm_decrypt, aes_256_gcm_encrypt, KeyAlgorithm, SoftHsm};
+    use crate::{AuthValue, Hsm, HsmIdentity};
+    use openssl::hash::MessageDigest;
+    use openssl::pkey::PKey;
+    use openssl::sign::Verifier;
     use std::str::FromStr;
     use tracing::trace;
 
@@ -342,5 +562,129 @@ mod tests {
 
         // It should be the same.
         assert_eq!(output_1, output_2);
+    }
+
+    #[test]
+    fn soft_identity_ecdsa256_hw_bound() {
+        let _ = tracing_subscriber::fmt::try_init();
+        // Create the Hsm.
+        let mut hsm = SoftHsm::new();
+
+        let auth_value =
+            AuthValue::from_str("Ohquiech9jis7Poo8Di7eth3").expect("Unable to create auth value");
+
+        // Request a new machine-key-context. This key "owns" anything
+        // created underneath it.
+        let loadable_machine_key = hsm
+            .machine_key_create(&auth_value)
+            .expect("Unable to create new machine key");
+
+        trace!(?loadable_machine_key);
+
+        let machine_key = hsm
+            .machine_key_load(&auth_value, &loadable_machine_key)
+            .expect("Unable to load machine key");
+
+        // from that ctx, create an identity key
+        let loadable_id_key = hsm
+            .identity_key_create(&machine_key, KeyAlgorithm::Ecdsa256)
+            .expect("Unable to create id key");
+
+        trace!(?loadable_id_key);
+
+        let id_key = hsm
+            .identity_key_load(&machine_key, &loadable_id_key)
+            .expect("Unable to load id key");
+
+        let id_key_public_pem = hsm
+            .identity_key_public_as_pem(&id_key)
+            .expect("Unable to get id key public pem");
+
+        let pem_str = String::from_utf8_lossy(&id_key_public_pem);
+        trace!(?pem_str);
+
+        let id_key_public_der = hsm
+            .identity_key_public_as_der(&id_key)
+            .expect("Unable to get id key public pem");
+
+        // Rehydrate the der to a public key.
+
+        let public_key = PKey::public_key_from_der(&id_key_public_der).expect("Invalid DER");
+
+        let input = "test string";
+        let signature = hsm
+            .identity_key_sign(&id_key, input.as_bytes())
+            .expect("Unable to sign input");
+
+        let mut verifier =
+            Verifier::new(MessageDigest::sha256(), &public_key).expect("Unable to setup verifier.");
+
+        let valid = verifier
+            .verify_oneshot(&signature, input.as_bytes())
+            .expect("Unable to validate signature");
+
+        assert!(valid);
+    }
+
+    #[test]
+    fn soft_identity_rsa2048_hw_bound() {
+        let _ = tracing_subscriber::fmt::try_init();
+        // Create the Hsm.
+        let mut hsm = SoftHsm::new();
+
+        let auth_value =
+            AuthValue::from_str("Ohquiech9jis7Poo8Di7eth3").expect("Unable to create auth value");
+
+        // Request a new machine-key-context. This key "owns" anything
+        // created underneath it.
+        let loadable_machine_key = hsm
+            .machine_key_create(&auth_value)
+            .expect("Unable to create new machine key");
+
+        trace!(?loadable_machine_key);
+
+        let machine_key = hsm
+            .machine_key_load(&auth_value, &loadable_machine_key)
+            .expect("Unable to load machine key");
+
+        // from that ctx, create an identity key
+        let loadable_id_key = hsm
+            .identity_key_create(&machine_key, KeyAlgorithm::Rsa2048)
+            .expect("Unable to create id key");
+
+        trace!(?loadable_id_key);
+
+        let id_key = hsm
+            .identity_key_load(&machine_key, &loadable_id_key)
+            .expect("Unable to load id key");
+
+        let id_key_public_pem = hsm
+            .identity_key_public_as_pem(&id_key)
+            .expect("Unable to get id key public pem");
+
+        let pem_str = String::from_utf8_lossy(&id_key_public_pem);
+        trace!(?pem_str);
+
+        let id_key_public_der = hsm
+            .identity_key_public_as_der(&id_key)
+            .expect("Unable to get id key public pem");
+
+        // Rehydrate the der to a public key.
+
+        let public_key = PKey::public_key_from_der(&id_key_public_der).expect("Invalid DER");
+
+        let input = "test string";
+        let signature = hsm
+            .identity_key_sign(&id_key, input.as_bytes())
+            .expect("Unable to sign input");
+
+        let mut verifier =
+            Verifier::new(MessageDigest::sha256(), &public_key).expect("Unable to setup verifier.");
+
+        let valid = verifier
+            .verify_oneshot(&signature, input.as_bytes())
+            .expect("Unable to validate signature");
+
+        assert!(valid);
     }
 }


### PR DESCRIPTION
Fixes #8 - this adds softhsm support for identity certs/keys. It already allows x509 certs to be associated with these, next we need to work out how to do the CSR's nicely. 

cc @dmulder 

## Checklist

- [ x ] This pr contains no AI generated code
- [ x ] cargo fmt has been run
- [ ] cargo clippy has been run and there's no issues
- [ x ] cargo test has been run and passes
