### PR TITLE
Traits must be public to import them externally

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,7 +143,7 @@ pub enum HsmError {
     Entropy,
 }
 
-trait Hsm {
+pub trait Hsm {
     type MachineKey;
     type LoadableMachineKey;
 
@@ -173,7 +173,7 @@ trait Hsm {
     fn hmac(&mut self, hk: &Self::HmacKey, input: &[u8]) -> Result<Vec<u8>, HsmError>;
 }
 
-trait HsmIdentity: Hsm {
+pub trait HsmIdentity: Hsm {
     type IdentityKey;
     type LoadableIdentityKey;
 


### PR DESCRIPTION
The functions implemented by these traits in SoftHsm were private and could not be imported.

(Refers|Fixes) #

## Checklist

- [x] This pr contains no AI generated code
- [x] cargo fmt has been run
- [x] cargo clippy has been run and there's no issues
- [x] cargo test has been run and passes
