### PR TITLE
20231101 kanidm integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kanidm-hsm-crypto"
 description = "A library for easily interacting with a HSM or TPM"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MPL-2.0"
 homepage = "https://github.com/kanidm/hsm-crypto/"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ tpm = ["dep:tss-esapi"]
 openssl = "^0.10.57"
 tracing = "^0.1.37"
 serde = { version = "^1.0", features = ["derive"] }
-tss-esapi = { version = "^7.3.0", optional = true }
+tss-esapi = { version = "^7.4.0", optional = true }
 zeroize = "1.6.0"
 argon2 = { version = "0.5.2", features = ["alloc"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "kanidm-hsm-crypto"
+description = "A library for easily interacting with a HSM or TPM"
 version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"
@@ -7,7 +8,6 @@ homepage = "https://github.com/kanidm/hsm-crypto/"
 repository = "https://github.com/kanidm/hsm-crypto/"
 authors = ["William Brown <william@blackhats.net.au>"]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
 # default = ["tpm"]
 tpm = ["dep:tss-esapi"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,11 +151,14 @@ pub enum HsmError {
 
     TpmHmacInputTooLarge,
 
+    TpmOperationUnsupported,
+
     Entropy,
     IncorrectKeyType,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
+#[cfg_attr(not(feature = "tpm"), derive(Serialize, Deserialize))]
 pub enum LoadableMachineKey {
     SoftAes256GcmV1 {
         key: Vec<u8>,
@@ -163,9 +166,12 @@ pub enum LoadableMachineKey {
         iv: [u8; 16],
     },
     #[cfg(feature = "tpm")]
-    Tpm(tpm::TpmLoadableMachineKey),
+    TpmAes128CfbV1 {
+        private: tpm::Private,
+        public: tpm::Public,
+    },
     #[cfg(not(feature = "tpm"))]
-    Tpm(()),
+    TpmAes128CfbV1 { private: (), public: () },
 }
 
 pub enum MachineKey {
@@ -173,12 +179,17 @@ pub enum MachineKey {
         key: Zeroizing<Vec<u8>>,
     },
     #[cfg(feature = "tpm")]
-    Tpm(tpm::TpmMachineKey),
+    Tpm {
+        key_handle: tpm::KeyHandle,
+    },
     #[cfg(not(feature = "tpm"))]
-    Tpm(()),
+    Tpm {
+        key_handle: (),
+    },
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
+#[cfg_attr(not(feature = "tpm"), derive(Serialize, Deserialize))]
 pub enum LoadableHmacKey {
     SoftSha256V1 {
         key: Vec<u8>,
@@ -186,7 +197,10 @@ pub enum LoadableHmacKey {
         iv: [u8; 16],
     },
     #[cfg(feature = "tpm")]
-    Tpm(tpm::TpmLoadableHmacKey),
+    TpmSha256V1 {
+        private: tpm::Private,
+        public: tpm::Public,
+    },
     #[cfg(not(feature = "tpm"))]
     Tpm(()),
 }
@@ -196,9 +210,13 @@ pub enum HmacKey {
         pkey: PKey<Private>,
     },
     #[cfg(feature = "tpm")]
-    Tpm(tpm::TpmHmacKey),
+    TpmSha256 {
+        key_handle: tpm::KeyHandle,
+    },
     #[cfg(not(feature = "tpm"))]
-    Tpm(()),
+    TpmSha256 {
+        key_handle: (),
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,6 +131,7 @@ pub enum TpmError {
     X509RequestToDer,
     X509RequestSetPublic,
 
+    TpmTctiNameInvalid,
     TpmContextCreate,
     TpmPrimaryObjectAttributesInvalid,
     TpmPrimaryPublicBuilderInvalid,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,11 +16,11 @@
 #![deny(clippy::manual_let_else)]
 #![allow(clippy::unreachable)]
 
+use argon2::MIN_SALT_LEN;
+use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use tracing::error;
 use zeroize::Zeroizing;
-use argon2::MIN_SALT_LEN;
-use serde::{Deserialize, Serialize};
 
 pub mod soft;
 
@@ -191,8 +191,7 @@ pub trait Hsm {
         exported_key: &LoadableMachineKey,
     ) -> Result<MachineKey, HsmError>;
 
-    fn hmac_key_create(&mut self, mk: &MachineKey)
-        -> Result<LoadableHmacKey, HsmError>;
+    fn hmac_key_create(&mut self, mk: &MachineKey) -> Result<LoadableHmacKey, HsmError>;
 
     fn hmac_key_load(
         &mut self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,11 +41,11 @@ pub enum KeyAlgorithm {
 }
 
 impl AuthValue {
-    pub fn new_random() -> Result<Self, HsmError> {
+    pub fn new_random() -> Result<Self, TpmError> {
         let mut auth_key = Zeroizing::new([0; 32]);
         openssl::rand::rand_bytes(auth_key.as_mut()).map_err(|ossl_err| {
             error!(?ossl_err);
-            HsmError::Entropy
+            TpmError::Entropy
         })?;
 
         Ok(AuthValue::Key256Bit { auth_key })
@@ -53,7 +53,7 @@ impl AuthValue {
 }
 
 impl TryFrom<&[u8]> for AuthValue {
-    type Error = HsmError;
+    type Error = TpmError;
 
     fn try_from(cleartext: &[u8]) -> Result<Self, Self::Error> {
         use argon2::{Algorithm, Argon2, Params, Version};
@@ -64,14 +64,14 @@ impl TryFrom<&[u8]> for AuthValue {
         let argon2id_params =
             Params::new(32_768, 4, 1, Some(auth_key.as_ref().len())).map_err(|argon_err| {
                 error!(?argon_err);
-                HsmError::AuthValueDerivation
+                TpmError::AuthValueDerivation
             })?;
 
         let argon = Argon2::new(Algorithm::Argon2id, Version::V0x13, argon2id_params);
 
         // Want at least 8 bytes salt, 16 bytes pw input.
         if cleartext.len() < 24 {
-            return Err(HsmError::AuthValueTooShort);
+            return Err(TpmError::AuthValueTooShort);
         }
 
         let (salt, key) = cleartext.split_at(MIN_SALT_LEN);
@@ -80,7 +80,7 @@ impl TryFrom<&[u8]> for AuthValue {
             .hash_password_into(key, salt, auth_key.as_mut())
             .map_err(|argon_err| {
                 error!(?argon_err);
-                HsmError::AuthValueDerivation
+                TpmError::AuthValueDerivation
             })?;
 
         Ok(AuthValue::Key256Bit { auth_key })
@@ -88,7 +88,7 @@ impl TryFrom<&[u8]> for AuthValue {
 }
 
 impl FromStr for AuthValue {
-    type Err = HsmError;
+    type Err = TpmError;
 
     fn from_str(cleartext: &str) -> Result<Self, Self::Err> {
         Self::try_from(cleartext.as_bytes())
@@ -96,7 +96,7 @@ impl FromStr for AuthValue {
 }
 
 #[derive(Debug, Clone)]
-pub enum HsmError {
+pub enum TpmError {
     AuthValueTooShort,
     AuthValueDerivation,
     Aes256GcmConfig,
@@ -246,61 +246,391 @@ pub enum IdentityKey {
     },
 }
 
-pub trait Hsm {
+pub trait Tpm {
     fn machine_key_create(
         &mut self,
         auth_value: &AuthValue,
-    ) -> Result<LoadableMachineKey, HsmError>;
+    ) -> Result<LoadableMachineKey, TpmError>;
 
     fn machine_key_load(
         &mut self,
         auth_value: &AuthValue,
         exported_key: &LoadableMachineKey,
-    ) -> Result<MachineKey, HsmError>;
+    ) -> Result<MachineKey, TpmError>;
 
-    fn hmac_key_create(&mut self, mk: &MachineKey) -> Result<LoadableHmacKey, HsmError>;
+    fn hmac_key_create(&mut self, mk: &MachineKey) -> Result<LoadableHmacKey, TpmError>;
 
     fn hmac_key_load(
         &mut self,
         mk: &MachineKey,
         exported_key: &LoadableHmacKey,
-    ) -> Result<HmacKey, HsmError>;
+    ) -> Result<HmacKey, TpmError>;
 
-    fn hmac(&mut self, hk: &HmacKey, input: &[u8]) -> Result<Vec<u8>, HsmError>;
+    fn hmac(&mut self, hk: &HmacKey, input: &[u8]) -> Result<Vec<u8>, TpmError>;
 
     fn identity_key_create(
         &mut self,
         mk: &MachineKey,
         algorithm: KeyAlgorithm,
-    ) -> Result<LoadableIdentityKey, HsmError>;
+    ) -> Result<LoadableIdentityKey, TpmError>;
 
     fn identity_key_load(
         &mut self,
         mk: &MachineKey,
         loadable_key: &LoadableIdentityKey,
-    ) -> Result<IdentityKey, HsmError>;
+    ) -> Result<IdentityKey, TpmError>;
 
-    fn identity_key_sign(&mut self, key: &IdentityKey, input: &[u8]) -> Result<Vec<u8>, HsmError>;
+    fn identity_key_sign(&mut self, key: &IdentityKey, input: &[u8]) -> Result<Vec<u8>, TpmError>;
 
     fn identity_key_certificate_request(
         &mut self,
         mk: &MachineKey,
         loadable_key: &LoadableIdentityKey,
         cn: &str,
-    ) -> Result<Vec<u8>, HsmError>;
+    ) -> Result<Vec<u8>, TpmError>;
 
     fn identity_key_associate_certificate(
         &mut self,
         mk: &MachineKey,
         loadable_key: &LoadableIdentityKey,
         certificate_der: &[u8],
-    ) -> Result<LoadableIdentityKey, HsmError>;
+    ) -> Result<LoadableIdentityKey, TpmError>;
 
-    fn identity_key_public_as_der(&mut self, key: &IdentityKey) -> Result<Vec<u8>, HsmError>;
+    fn identity_key_public_as_der(&mut self, key: &IdentityKey) -> Result<Vec<u8>, TpmError>;
 
-    fn identity_key_public_as_pem(&mut self, key: &IdentityKey) -> Result<Vec<u8>, HsmError>;
+    fn identity_key_public_as_pem(&mut self, key: &IdentityKey) -> Result<Vec<u8>, TpmError>;
 
-    fn identity_key_x509_as_pem(&mut self, key: &IdentityKey) -> Result<Vec<u8>, HsmError>;
+    fn identity_key_x509_as_pem(&mut self, key: &IdentityKey) -> Result<Vec<u8>, TpmError>;
 
-    fn identity_key_x509_as_der(&mut self, key: &IdentityKey) -> Result<Vec<u8>, HsmError>;
+    fn identity_key_x509_as_der(&mut self, key: &IdentityKey) -> Result<Vec<u8>, TpmError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use openssl::asn1::Asn1Time;
+    use openssl::bn::BigNum;
+    use openssl::ec::{EcGroup, EcKey};
+    use openssl::hash::MessageDigest;
+    use openssl::nid::Nid;
+    use openssl::pkey::{PKey, Private};
+    use openssl::x509::extension::{
+        BasicConstraints, ExtendedKeyUsage, KeyUsage, SubjectKeyIdentifier,
+    };
+    use openssl::x509::{X509NameBuilder, X509Req, X509};
+
+    #[macro_export]
+    macro_rules! test_tpm_hmac {
+        ( $tpm_a:expr, $tpm_b:expr ) => {
+            use crate::{AuthValue, Tpm};
+            use tracing::trace;
+
+            let _ = tracing_subscriber::fmt::try_init();
+
+            // Create a new random auth_value.
+            let auth_value = AuthValue::new_random().expect("Failed to generate new random secret");
+
+            // Request a new machine-key-context. This key "owns" anything
+            // created underneath it.
+            let loadable_machine_key = $tpm_a
+                .machine_key_create(&auth_value)
+                .expect("Unable to create new machine key");
+
+            trace!(?loadable_machine_key);
+
+            let machine_key = $tpm_a
+                .machine_key_load(&auth_value, &loadable_machine_key)
+                .expect("Unable to load machine key");
+
+            // from that ctx, create a hmac key.
+            let loadable_hmac_key = $tpm_a
+                .hmac_key_create(&machine_key)
+                .expect("Unable to create new hmac key");
+
+            trace!(?loadable_hmac_key);
+
+            let hmac_key = $tpm_a
+                .hmac_key_load(&machine_key, &loadable_hmac_key)
+                .expect("Unable to load hmac key");
+
+            // do a hmac.
+            let output_1 = $tpm_a
+                .hmac(&hmac_key, &[0, 1, 2, 3])
+                .expect("Unable to perform hmac");
+
+            // destroy the Hsm
+            drop(hmac_key);
+            drop(machine_key);
+            drop($tpm_a);
+
+            // Load the contexts.
+            let machine_key = $tpm_b
+                .machine_key_load(&auth_value, &loadable_machine_key)
+                .expect("Unable to load machine key");
+
+            // Load the keys.
+            let hmac_key = $tpm_b
+                .hmac_key_load(&machine_key, &loadable_hmac_key)
+                .expect("Unable to load hmac key");
+
+            // Do another hmac
+            let output_2 = $tpm_b
+                .hmac(&hmac_key, &[0, 1, 2, 3])
+                .expect("Unable to perform hmac");
+
+            // It should be the same.
+            assert_eq!(output_1, output_2);
+        };
+    }
+
+    #[macro_export]
+    macro_rules! test_tpm_identity {
+        ( $tpm:expr, $alg:expr ) => {
+            use crate::{AuthValue, Tpm};
+            use openssl::hash::MessageDigest;
+            use openssl::pkey::PKey;
+            use openssl::sign::Verifier;
+            use std::str::FromStr;
+            use tracing::trace;
+
+            let _ = tracing_subscriber::fmt::try_init();
+
+            let auth_value = AuthValue::from_str("Ohquiech9jis7Poo8Di7eth3")
+                .expect("Unable to create auth value");
+
+            // Request a new machine-key-context. This key "owns" anything
+            // created underneath it.
+            let loadable_machine_key = $tpm
+                .machine_key_create(&auth_value)
+                .expect("Unable to create new machine key");
+
+            trace!(?loadable_machine_key);
+
+            let machine_key = $tpm
+                .machine_key_load(&auth_value, &loadable_machine_key)
+                .expect("Unable to load machine key");
+
+            // from that ctx, create an identity key
+            let loadable_id_key = $tpm
+                .identity_key_create(&machine_key, $alg)
+                .expect("Unable to create id key");
+
+            trace!(?loadable_id_key);
+
+            let id_key = $tpm
+                .identity_key_load(&machine_key, &loadable_id_key)
+                .expect("Unable to load id key");
+
+            let id_key_public_pem = $tpm
+                .identity_key_public_as_pem(&id_key)
+                .expect("Unable to get id key public pem");
+
+            let pem_str = String::from_utf8_lossy(&id_key_public_pem);
+            trace!(?pem_str);
+
+            let id_key_public_der = $tpm
+                .identity_key_public_as_der(&id_key)
+                .expect("Unable to get id key public pem");
+
+            // Rehydrate the der to a public key.
+
+            let public_key = PKey::public_key_from_der(&id_key_public_der).expect("Invalid DER");
+
+            let input = "test string";
+            let signature = $tpm
+                .identity_key_sign(&id_key, input.as_bytes())
+                .expect("Unable to sign input");
+
+            let mut verifier = Verifier::new(MessageDigest::sha256(), &public_key)
+                .expect("Unable to setup verifier.");
+
+            let valid = verifier
+                .verify_oneshot(&signature, input.as_bytes())
+                .expect("Unable to validate signature");
+
+            assert!(valid);
+        };
+    }
+
+    #[macro_export]
+    macro_rules! test_tpm_identity_csr {
+        ( $tpm:expr, $alg:expr ) => {
+            use crate::{AuthValue, Tpm};
+            use std::str::FromStr;
+            use tracing::trace;
+
+            let _ = tracing_subscriber::fmt::try_init();
+
+            let auth_value = AuthValue::from_str("Ohquiech9jis7Poo8Di7eth3")
+                .expect("Unable to create auth value");
+
+            // Request a new machine-key-context. This key "owns" anything
+            // created underneath it.
+            let loadable_machine_key = $tpm
+                .machine_key_create(&auth_value)
+                .expect("Unable to create new machine key");
+
+            trace!(?loadable_machine_key);
+
+            let machine_key = $tpm
+                .machine_key_load(&auth_value, &loadable_machine_key)
+                .expect("Unable to load machine key");
+
+            // from that ctx, create an identity key
+            let loadable_id_key = $tpm
+                .identity_key_create(&machine_key, $alg)
+                .expect("Unable to create id key");
+
+            trace!(?loadable_id_key);
+
+            // Get the CSR
+
+            let csr_der = $tpm
+                .identity_key_certificate_request(&machine_key, &loadable_id_key, "common name")
+                .expect("Failed to create csr");
+
+            // Now, we need to sign this to an x509 cert externally.
+            let (ca_key, ca_cert) = crate::tests::create_ca();
+
+            let signed_cert = crate::tests::sign_request(&csr_der, &ca_key, &ca_cert);
+            trace!(
+                "{}",
+                String::from_utf8_lossy(signed_cert.to_text().unwrap().as_slice())
+            );
+
+            let signed_cert_der = signed_cert.to_der().unwrap();
+
+            let loadable_id_key = $tpm
+                .identity_key_associate_certificate(
+                    &machine_key,
+                    &loadable_id_key,
+                    &signed_cert_der,
+                )
+                .unwrap();
+
+            // Now load it in:
+            let id_key = $tpm
+                .identity_key_load(&machine_key, &loadable_id_key)
+                .expect("Unable to load id key");
+
+            let id_key_x509_pem = $tpm
+                .identity_key_x509_as_pem(&id_key)
+                .expect("Unable to get id key public pem");
+
+            trace!("\n{}", String::from_utf8_lossy(&id_key_x509_pem));
+        };
+    }
+
+    pub fn create_ca() -> (PKey<Private>, X509) {
+        let ecgroup = EcGroup::from_curve_name(Nid::X9_62_PRIME256V1).unwrap();
+        let eckey = EcKey::generate(&ecgroup).unwrap();
+        let ca_key = PKey::from_ec_key(eckey).unwrap();
+
+        let mut x509_name = X509NameBuilder::new().unwrap();
+        x509_name
+            .append_entry_by_text("CN", "Dynamic Softtoken CA")
+            .unwrap();
+        let x509_name = x509_name.build();
+
+        let mut cert_builder = X509::builder().unwrap();
+        cert_builder.set_version(2).unwrap();
+
+        let serial_number = BigNum::from_u32(1)
+            .and_then(|serial| serial.to_asn1_integer())
+            .unwrap();
+        cert_builder.set_serial_number(&serial_number).unwrap();
+        cert_builder.set_subject_name(&x509_name).unwrap();
+        cert_builder.set_issuer_name(&x509_name).unwrap();
+
+        let not_before = Asn1Time::days_from_now(0).unwrap();
+        cert_builder.set_not_before(&not_before).unwrap();
+        let not_after = Asn1Time::days_from_now(1).unwrap();
+        cert_builder.set_not_after(&not_after).unwrap();
+
+        cert_builder
+            .append_extension(BasicConstraints::new().critical().ca().build().unwrap())
+            .unwrap();
+        cert_builder
+            .append_extension(
+                KeyUsage::new()
+                    .critical()
+                    .key_cert_sign()
+                    .crl_sign()
+                    .build()
+                    .unwrap(),
+            )
+            .unwrap();
+
+        let subject_key_identifier = SubjectKeyIdentifier::new()
+            .build(&cert_builder.x509v3_context(None, None))
+            .unwrap();
+        cert_builder
+            .append_extension(subject_key_identifier)
+            .unwrap();
+
+        cert_builder.set_pubkey(&ca_key).unwrap();
+
+        cert_builder.sign(&ca_key, MessageDigest::sha256()).unwrap();
+        let ca_cert = cert_builder.build();
+
+        (ca_key, ca_cert)
+    }
+
+    pub fn sign_request(req_der: &[u8], ca_key: &PKey<Private>, ca_cert: &X509) -> X509 {
+        let req = X509Req::from_der(req_der).unwrap();
+
+        let req_pkey = req.public_key().unwrap();
+        assert!(req.verify(&req_pkey).unwrap());
+
+        // depends on the ca, for a lot of them with machine id certs they ignore the values in
+        // the csr and stomp them with their own things.
+
+        let mut cert_builder = X509::builder().unwrap();
+        cert_builder.set_version(2).unwrap();
+
+        let serial_number = BigNum::from_u32(2)
+            .and_then(|serial| serial.to_asn1_integer())
+            .unwrap();
+        cert_builder.set_serial_number(&serial_number).unwrap();
+        cert_builder.set_subject_name(req.subject_name()).unwrap();
+        cert_builder
+            .set_issuer_name(ca_cert.subject_name())
+            .unwrap();
+
+        let not_before = Asn1Time::days_from_now(0).unwrap();
+        cert_builder.set_not_before(&not_before).unwrap();
+        let not_after = Asn1Time::days_from_now(1).unwrap();
+        cert_builder.set_not_after(&not_after).unwrap();
+
+        cert_builder
+            .append_extension(BasicConstraints::new().critical().build().unwrap())
+            .unwrap();
+
+        /*
+        cert_builder.append_extension(
+            KeyUsage::new()
+                .critical()
+                .digital_signature()
+                .key_encipherment()
+                .build().unwrap()
+        ).unwrap();
+
+        let subject_key_identifier = SubjectKeyIdentifier::new().build(&cert_builder.x509v3_context(None, None)).unwrap();
+        cert_builder.append_extension(subject_key_identifier).unwrap();
+        */
+
+        cert_builder
+            .append_extension(
+                ExtendedKeyUsage::new()
+                    // .server_auth()
+                    .client_auth()
+                    .build()
+                    .unwrap(),
+            )
+            .unwrap();
+
+        cert_builder.set_pubkey(&req_pkey).unwrap();
+
+        cert_builder.sign(&ca_key, MessageDigest::sha256()).unwrap();
+        cert_builder.build()
+    }
 }

--- a/src/soft.rs
+++ b/src/soft.rs
@@ -67,7 +67,7 @@ impl Hsm for SoftHsm {
                 };
                 Ok(MachineKey::SoftAes256Gcm { key: raw_key })
             }
-            LoadableMachineKey::Tpm(_) => Err(HsmError::IncorrectKeyType),
+            LoadableMachineKey::TpmAes128CfbV1 { .. } => Err(HsmError::IncorrectKeyType),
         }
     }
 
@@ -88,7 +88,7 @@ impl Hsm for SoftHsm {
             MachineKey::SoftAes256Gcm { key } => {
                 aes_256_gcm_encrypt(buf.as_ref(), key.as_ref(), &iv)?
             }
-            MachineKey::Tpm(_) => return Err(HsmError::IncorrectKeyType),
+            MachineKey::Tpm { .. } => return Err(HsmError::IncorrectKeyType),
         };
 
         Ok(LoadableHmacKey::SoftSha256V1 { key, tag, iv })
@@ -136,7 +136,7 @@ impl Hsm for SoftHsm {
                     HsmError::HmacSign
                 })
             }
-            HmacKey::Tpm(_) => Err(HsmError::IncorrectKeyType),
+            HmacKey::TpmSha256 { .. } => Err(HsmError::IncorrectKeyType),
         }
     }
 
@@ -176,7 +176,7 @@ impl Hsm for SoftHsm {
                     MachineKey::SoftAes256Gcm { key } => {
                         aes_256_gcm_encrypt(der.as_ref(), key.as_ref(), &iv)?
                     }
-                    MachineKey::Tpm(_) => return Err(HsmError::IncorrectKeyType),
+                    MachineKey::Tpm { .. } => return Err(HsmError::IncorrectKeyType),
                 };
 
                 let x509 = None;
@@ -207,7 +207,7 @@ impl Hsm for SoftHsm {
                     MachineKey::SoftAes256Gcm { key } => {
                         aes_256_gcm_encrypt(der.as_ref(), key.as_ref(), &iv)?
                     }
-                    MachineKey::Tpm(_) => return Err(HsmError::IncorrectKeyType),
+                    MachineKey::Tpm { .. } => return Err(HsmError::IncorrectKeyType),
                 };
 
                 let x509 = None;
@@ -563,7 +563,7 @@ fn aes_256_gcm_decrypt(
 #[cfg(test)]
 mod tests {
     use super::{aes_256_gcm_decrypt, aes_256_gcm_encrypt, KeyAlgorithm, SoftHsm};
-    use crate::{AuthValue, Hsm, HsmIdentity};
+    use crate::{AuthValue, Hsm};
     use openssl::asn1::Asn1Time;
     use openssl::bn::BigNum;
     use openssl::ec::{EcGroup, EcKey};

--- a/src/soft.rs
+++ b/src/soft.rs
@@ -1,6 +1,6 @@
 use crate::{
-    AuthValue, HmacKey, Hsm, HsmError, IdentityKey, KeyAlgorithm, LoadableHmacKey,
-    LoadableIdentityKey, LoadableMachineKey, MachineKey,
+    AuthValue, HmacKey, IdentityKey, KeyAlgorithm, LoadableHmacKey, LoadableIdentityKey,
+    LoadableMachineKey, MachineKey, Tpm, TpmError,
 };
 use zeroize::Zeroizing;
 
@@ -17,31 +17,31 @@ use openssl::x509::{X509NameBuilder, X509ReqBuilder, X509};
 use tracing::error;
 
 #[derive(Default)]
-pub struct SoftHsm {}
+pub struct SoftTpm {}
 
-impl SoftHsm {
+impl SoftTpm {
     pub fn new() -> Self {
         Self::default()
     }
 }
 
-impl Hsm for SoftHsm {
+impl Tpm for SoftTpm {
     fn machine_key_create(
         &mut self,
         auth_value: &AuthValue,
-    ) -> Result<LoadableMachineKey, HsmError> {
+    ) -> Result<LoadableMachineKey, TpmError> {
         // Create a "machine binding" key.
         let mut buf = Zeroizing::new([0; 32]);
         rand_bytes(buf.as_mut()).map_err(|ossl_err| {
             error!(?ossl_err);
-            HsmError::Entropy
+            TpmError::Entropy
         })?;
 
         // Encrypt it.
         let mut iv = [0; 16];
         rand_bytes(&mut iv).map_err(|ossl_err| {
             error!(?ossl_err);
-            HsmError::Entropy
+            TpmError::Entropy
         })?;
 
         let (key, tag) = match auth_value {
@@ -57,7 +57,7 @@ impl Hsm for SoftHsm {
         &mut self,
         auth_value: &AuthValue,
         loadable_key: &LoadableMachineKey,
-    ) -> Result<MachineKey, HsmError> {
+    ) -> Result<MachineKey, TpmError> {
         match loadable_key {
             LoadableMachineKey::SoftAes256GcmV1 { key, tag, iv } => {
                 let raw_key = match auth_value {
@@ -67,28 +67,28 @@ impl Hsm for SoftHsm {
                 };
                 Ok(MachineKey::SoftAes256Gcm { key: raw_key })
             }
-            LoadableMachineKey::TpmAes128CfbV1 { .. } => Err(HsmError::IncorrectKeyType),
+            LoadableMachineKey::TpmAes128CfbV1 { .. } => Err(TpmError::IncorrectKeyType),
         }
     }
 
-    fn hmac_key_create(&mut self, mk: &MachineKey) -> Result<LoadableHmacKey, HsmError> {
+    fn hmac_key_create(&mut self, mk: &MachineKey) -> Result<LoadableHmacKey, TpmError> {
         let mut buf = Zeroizing::new([0; 32]);
         rand_bytes(buf.as_mut()).map_err(|ossl_err| {
             error!(?ossl_err);
-            HsmError::Entropy
+            TpmError::Entropy
         })?;
 
         let mut iv = [0; 16];
         rand_bytes(&mut iv).map_err(|ossl_err| {
             error!(?ossl_err);
-            HsmError::Entropy
+            TpmError::Entropy
         })?;
 
         let (key, tag) = match mk {
             MachineKey::SoftAes256Gcm { key } => {
                 aes_256_gcm_encrypt(buf.as_ref(), key.as_ref(), &iv)?
             }
-            MachineKey::Tpm { .. } => return Err(HsmError::IncorrectKeyType),
+            MachineKey::Tpm { .. } => return Err(TpmError::IncorrectKeyType),
         };
 
         Ok(LoadableHmacKey::SoftSha256V1 { key, tag, iv })
@@ -98,7 +98,7 @@ impl Hsm for SoftHsm {
         &mut self,
         mk: &MachineKey,
         loadable_key: &LoadableHmacKey,
-    ) -> Result<HmacKey, HsmError> {
+    ) -> Result<HmacKey, TpmError> {
         match (mk, loadable_key) {
             (
                 MachineKey::SoftAes256Gcm { key: mk_key },
@@ -108,35 +108,35 @@ impl Hsm for SoftHsm {
 
                 let pkey = PKey::hmac(raw_key.as_ref()).map_err(|ossl_err| {
                     error!(?ossl_err);
-                    HsmError::HmacKey
+                    TpmError::HmacKey
                 })?;
 
                 Ok(HmacKey::SoftSha256 { pkey })
             }
-            (_, _) => Err(HsmError::IncorrectKeyType),
+            (_, _) => Err(TpmError::IncorrectKeyType),
         }
     }
 
-    fn hmac(&mut self, hk: &HmacKey, input: &[u8]) -> Result<Vec<u8>, HsmError> {
+    fn hmac(&mut self, hk: &HmacKey, input: &[u8]) -> Result<Vec<u8>, TpmError> {
         match hk {
             HmacKey::SoftSha256 { pkey } => {
                 let mut signer =
                     Signer::new(MessageDigest::sha256(), pkey).map_err(|ossl_err| {
                         error!(?ossl_err);
-                        HsmError::HmacKey
+                        TpmError::HmacKey
                     })?;
 
                 signer.update(input).map_err(|ossl_err| {
                     error!(?ossl_err);
-                    HsmError::HmacSign
+                    TpmError::HmacSign
                 })?;
 
                 signer.sign_to_vec().map_err(|ossl_err| {
                     error!(?ossl_err);
-                    HsmError::HmacSign
+                    TpmError::HmacSign
                 })
             }
-            HmacKey::TpmSha256 { .. } => Err(HsmError::IncorrectKeyType),
+            HmacKey::TpmSha256 { .. } => Err(TpmError::IncorrectKeyType),
         }
     }
 
@@ -144,18 +144,18 @@ impl Hsm for SoftHsm {
         &mut self,
         mk: &MachineKey,
         algorithm: KeyAlgorithm,
-    ) -> Result<LoadableIdentityKey, HsmError> {
+    ) -> Result<LoadableIdentityKey, TpmError> {
         match algorithm {
             KeyAlgorithm::Ecdsa256 => {
                 let ecgroup =
                     EcGroup::from_curve_name(Nid::X9_62_PRIME256V1).map_err(|ossl_err| {
                         error!(?ossl_err);
-                        HsmError::EcGroup
+                        TpmError::EcGroup
                     })?;
 
                 let eckey = EcKey::generate(&ecgroup).map_err(|ossl_err| {
                     error!(?ossl_err);
-                    HsmError::EcKeyGenerate
+                    TpmError::EcKeyGenerate
                 })?;
 
                 let der = eckey
@@ -163,20 +163,20 @@ impl Hsm for SoftHsm {
                     .map(Zeroizing::new)
                     .map_err(|ossl_err| {
                         error!(?ossl_err);
-                        HsmError::EcKeyPrivateToDer
+                        TpmError::EcKeyPrivateToDer
                     })?;
 
                 let mut iv = [0; 16];
                 rand_bytes(&mut iv).map_err(|ossl_err| {
                     error!(?ossl_err);
-                    HsmError::Entropy
+                    TpmError::Entropy
                 })?;
 
                 let (key, tag) = match mk {
                     MachineKey::SoftAes256Gcm { key } => {
                         aes_256_gcm_encrypt(der.as_ref(), key.as_ref(), &iv)?
                     }
-                    MachineKey::Tpm { .. } => return Err(HsmError::IncorrectKeyType),
+                    MachineKey::Tpm { .. } => return Err(TpmError::IncorrectKeyType),
                 };
 
                 let x509 = None;
@@ -186,7 +186,7 @@ impl Hsm for SoftHsm {
             KeyAlgorithm::Rsa2048 => {
                 let rsa = Rsa::generate(2048).map_err(|ossl_err| {
                     error!(?ossl_err);
-                    HsmError::RsaGenerate
+                    TpmError::RsaGenerate
                 })?;
 
                 let der = rsa
@@ -194,20 +194,20 @@ impl Hsm for SoftHsm {
                     .map(Zeroizing::new)
                     .map_err(|ossl_err| {
                         error!(?ossl_err);
-                        HsmError::RsaPrivateToDer
+                        TpmError::RsaPrivateToDer
                     })?;
 
                 let mut iv = [0; 16];
                 rand_bytes(&mut iv).map_err(|ossl_err| {
                     error!(?ossl_err);
-                    HsmError::Entropy
+                    TpmError::Entropy
                 })?;
 
                 let (key, tag) = match mk {
                     MachineKey::SoftAes256Gcm { key } => {
                         aes_256_gcm_encrypt(der.as_ref(), key.as_ref(), &iv)?
                     }
-                    MachineKey::Tpm { .. } => return Err(HsmError::IncorrectKeyType),
+                    MachineKey::Tpm { .. } => return Err(TpmError::IncorrectKeyType),
                 };
 
                 let x509 = None;
@@ -221,7 +221,7 @@ impl Hsm for SoftHsm {
         &mut self,
         mk: &MachineKey,
         loadable_key: &LoadableIdentityKey,
-    ) -> Result<IdentityKey, HsmError> {
+    ) -> Result<IdentityKey, TpmError> {
         match (mk, loadable_key) {
             (
                 MachineKey::SoftAes256Gcm { key: mk_key },
@@ -231,28 +231,28 @@ impl Hsm for SoftHsm {
 
                 let eckey = EcKey::private_key_from_der(key_der.as_ref()).map_err(|ossl_err| {
                     error!(?ossl_err);
-                    HsmError::EcKeyFromDer
+                    TpmError::EcKeyFromDer
                 })?;
 
                 let pkey = PKey::from_ec_key(eckey).map_err(|ossl_err| {
                     error!(?ossl_err);
-                    HsmError::EcKeyToPrivateKey
+                    TpmError::EcKeyToPrivateKey
                 })?;
 
                 let x509 = match x509 {
                     Some(der) => {
                         let x509 = X509::from_der(der).map_err(|ossl_err| {
                             error!(?ossl_err);
-                            HsmError::X509FromDer
+                            TpmError::X509FromDer
                         })?;
 
                         let x509_pkey = x509.public_key().map_err(|ossl_err| {
                             error!(?ossl_err);
-                            HsmError::X509PublicKey
+                            TpmError::X509PublicKey
                         })?;
 
                         if !pkey.public_eq(&x509_pkey) {
-                            return Err(HsmError::X509KeyMismatch);
+                            return Err(TpmError::X509KeyMismatch);
                         }
 
                         Some(x509)
@@ -270,28 +270,28 @@ impl Hsm for SoftHsm {
 
                 let eckey = Rsa::private_key_from_der(key_der.as_ref()).map_err(|ossl_err| {
                     error!(?ossl_err);
-                    HsmError::RsaKeyFromDer
+                    TpmError::RsaKeyFromDer
                 })?;
 
                 let pkey = PKey::from_rsa(eckey).map_err(|ossl_err| {
                     error!(?ossl_err);
-                    HsmError::RsaToPrivateKey
+                    TpmError::RsaToPrivateKey
                 })?;
 
                 let x509 = match x509 {
                     Some(der) => {
                         let x509 = X509::from_der(der).map_err(|ossl_err| {
                             error!(?ossl_err);
-                            HsmError::X509FromDer
+                            TpmError::X509FromDer
                         })?;
 
                         let x509_pkey = x509.public_key().map_err(|ossl_err| {
                             error!(?ossl_err);
-                            HsmError::X509PublicKey
+                            TpmError::X509PublicKey
                         })?;
 
                         if !pkey.public_eq(&x509_pkey) {
-                            return Err(HsmError::X509KeyMismatch);
+                            return Err(TpmError::X509KeyMismatch);
                         }
 
                         Some(x509)
@@ -301,35 +301,35 @@ impl Hsm for SoftHsm {
 
                 Ok(IdentityKey::SoftRsa2048 { pkey, x509 })
             }
-            (_, _) => Err(HsmError::IncorrectKeyType),
+            (_, _) => Err(TpmError::IncorrectKeyType),
         }
     }
 
-    fn identity_key_public_as_der(&mut self, key: &IdentityKey) -> Result<Vec<u8>, HsmError> {
+    fn identity_key_public_as_der(&mut self, key: &IdentityKey) -> Result<Vec<u8>, TpmError> {
         match key {
             IdentityKey::SoftEcdsa256 { pkey, x509: _ }
             | IdentityKey::SoftRsa2048 { pkey, x509: _ } => {
                 pkey.public_key_to_der().map_err(|ossl_err| {
                     error!(?ossl_err);
-                    HsmError::IdentityKeyPublicToDer
+                    TpmError::IdentityKeyPublicToDer
                 })
             }
         }
     }
 
-    fn identity_key_public_as_pem(&mut self, key: &IdentityKey) -> Result<Vec<u8>, HsmError> {
+    fn identity_key_public_as_pem(&mut self, key: &IdentityKey) -> Result<Vec<u8>, TpmError> {
         match key {
             IdentityKey::SoftEcdsa256 { pkey, x509: _ }
             | IdentityKey::SoftRsa2048 { pkey, x509: _ } => {
                 pkey.public_key_to_pem().map_err(|ossl_err| {
                     error!(?ossl_err);
-                    HsmError::IdentityKeyPublicToPem
+                    TpmError::IdentityKeyPublicToPem
                 })
             }
         }
     }
 
-    fn identity_key_x509_as_pem(&mut self, key: &IdentityKey) -> Result<Vec<u8>, HsmError> {
+    fn identity_key_x509_as_pem(&mut self, key: &IdentityKey) -> Result<Vec<u8>, TpmError> {
         match key {
             IdentityKey::SoftEcdsa256 {
                 pkey: _,
@@ -340,13 +340,13 @@ impl Hsm for SoftHsm {
                 x509: Some(x509),
             } => x509.to_pem().map_err(|ossl_err| {
                 error!(?ossl_err);
-                HsmError::IdentityKeyX509ToPem
+                TpmError::IdentityKeyX509ToPem
             }),
-            _ => Err(HsmError::IdentityKeyX509Missing),
+            _ => Err(TpmError::IdentityKeyX509Missing),
         }
     }
 
-    fn identity_key_x509_as_der(&mut self, key: &IdentityKey) -> Result<Vec<u8>, HsmError> {
+    fn identity_key_x509_as_der(&mut self, key: &IdentityKey) -> Result<Vec<u8>, TpmError> {
         match key {
             IdentityKey::SoftEcdsa256 {
                 pkey: _,
@@ -357,26 +357,26 @@ impl Hsm for SoftHsm {
                 x509: Some(x509),
             } => x509.to_der().map_err(|ossl_err| {
                 error!(?ossl_err);
-                HsmError::IdentityKeyX509ToDer
+                TpmError::IdentityKeyX509ToDer
             }),
-            _ => Err(HsmError::IdentityKeyX509Missing),
+            _ => Err(TpmError::IdentityKeyX509Missing),
         }
     }
 
-    fn identity_key_sign(&mut self, key: &IdentityKey, input: &[u8]) -> Result<Vec<u8>, HsmError> {
+    fn identity_key_sign(&mut self, key: &IdentityKey, input: &[u8]) -> Result<Vec<u8>, TpmError> {
         let mut signer = match key {
             IdentityKey::SoftEcdsa256 { pkey, x509: _ }
             | IdentityKey::SoftRsa2048 { pkey, x509: _ } => {
                 Signer::new(MessageDigest::sha256(), pkey).map_err(|ossl_err| {
                     error!(?ossl_err);
-                    HsmError::IdentityKeyInvalidForSigning
+                    TpmError::IdentityKeyInvalidForSigning
                 })?
             }
         };
 
         signer.sign_oneshot_to_vec(input).map_err(|ossl_err| {
             error!(?ossl_err);
-            HsmError::IdentityKeySignature
+            TpmError::IdentityKeySignature
         })
     }
 
@@ -385,24 +385,24 @@ impl Hsm for SoftHsm {
         mk: &MachineKey,
         loadable_key: &LoadableIdentityKey,
         cn: &str,
-    ) -> Result<Vec<u8>, HsmError> {
+    ) -> Result<Vec<u8>, TpmError> {
         let id_key = self.identity_key_load(mk, loadable_key)?;
 
         let mut req_builder = X509ReqBuilder::new().map_err(|ossl_err| {
             error!(?ossl_err);
-            HsmError::X509RequestBuilder
+            TpmError::X509RequestBuilder
         })?;
 
         let mut x509_name = X509NameBuilder::new().map_err(|ossl_err| {
             error!(?ossl_err);
-            HsmError::X509NameBuilder
+            TpmError::X509NameBuilder
         })?;
 
         x509_name
             .append_entry_by_text("CN", cn)
             .map_err(|ossl_err| {
                 error!(?ossl_err);
-                HsmError::X509NameAppend
+                TpmError::X509NameAppend
             })?;
 
         let x509_name = x509_name.build();
@@ -410,7 +410,7 @@ impl Hsm for SoftHsm {
             .set_subject_name(&x509_name)
             .map_err(|ossl_err| {
                 error!(?ossl_err);
-                HsmError::X509RequestSubjectName
+                TpmError::X509RequestSubjectName
             })?;
 
         match id_key {
@@ -418,21 +418,21 @@ impl Hsm for SoftHsm {
             | IdentityKey::SoftRsa2048 { pkey, x509: _ } => {
                 req_builder.set_pubkey(&pkey).map_err(|ossl_err| {
                     error!(?ossl_err);
-                    HsmError::X509RequestSetPublic
+                    TpmError::X509RequestSetPublic
                 })?;
 
                 req_builder
                     .sign(&pkey, MessageDigest::sha256())
                     .map_err(|ossl_err| {
                         error!(?ossl_err);
-                        HsmError::X509RequestSign
+                        TpmError::X509RequestSign
                     })?;
             }
         }
 
         req_builder.build().to_der().map_err(|ossl_err| {
             error!(?ossl_err);
-            HsmError::X509RequestToDer
+            TpmError::X509RequestToDer
         })
     }
 
@@ -441,25 +441,25 @@ impl Hsm for SoftHsm {
         mk: &MachineKey,
         loadable_key: &LoadableIdentityKey,
         certificate_der: &[u8],
-    ) -> Result<LoadableIdentityKey, HsmError> {
+    ) -> Result<LoadableIdentityKey, TpmError> {
         let id_key = self.identity_key_load(mk, loadable_key)?;
 
         // Verify the certificate matches our key
         let certificate = X509::from_der(certificate_der).map_err(|ossl_err| {
             error!(?ossl_err);
-            HsmError::X509FromDer
+            TpmError::X509FromDer
         })?;
 
         let certificate_pkey = certificate.public_key().map_err(|ossl_err| {
             error!(?ossl_err);
-            HsmError::X509PublicKey
+            TpmError::X509PublicKey
         })?;
 
         match id_key {
             IdentityKey::SoftEcdsa256 { pkey, x509: _ }
             | IdentityKey::SoftRsa2048 { pkey, x509: _ } => {
                 if !pkey.public_eq(&certificate_pkey) {
-                    return Err(HsmError::X509KeyMismatch);
+                    return Err(TpmError::X509KeyMismatch);
                 }
             }
         };
@@ -486,7 +486,7 @@ fn aes_256_gcm_encrypt(
     input: &[u8],
     key: &[u8],
     iv: &[u8],
-) -> Result<(Vec<u8>, [u8; 16]), HsmError> {
+) -> Result<(Vec<u8>, [u8; 16]), TpmError> {
     let cipher = Cipher::aes_256_gcm();
 
     let block_size = cipher.block_size();
@@ -494,7 +494,7 @@ fn aes_256_gcm_encrypt(
 
     let mut encrypter = Crypter::new(cipher, Mode::Encrypt, key, Some(iv)).map_err(|ossl_err| {
         error!(?ossl_err);
-        HsmError::Aes256GcmConfig
+        TpmError::Aes256GcmConfig
     })?;
 
     // Enable padding.
@@ -504,18 +504,18 @@ fn aes_256_gcm_encrypt(
         .update(input, &mut ciphertext)
         .map_err(|ossl_err| {
             error!(?ossl_err);
-            HsmError::Aes256GcmEncrypt
+            TpmError::Aes256GcmEncrypt
         })?;
     count += encrypter.finalize(&mut ciphertext).map_err(|ossl_err| {
         error!(?ossl_err);
-        HsmError::Aes256GcmEncrypt
+        TpmError::Aes256GcmEncrypt
     })?;
     ciphertext.truncate(count);
 
     let mut tag = [0; 16];
     encrypter.get_tag(&mut tag).map_err(|ossl_err| {
         error!(?ossl_err);
-        HsmError::Aes256GcmEncrypt
+        TpmError::Aes256GcmEncrypt
     })?;
 
     Ok((ciphertext, tag))
@@ -526,7 +526,7 @@ fn aes_256_gcm_decrypt(
     tag: &[u8],
     key: &[u8],
     iv: &[u8],
-) -> Result<Zeroizing<Vec<u8>>, HsmError> {
+) -> Result<Zeroizing<Vec<u8>>, TpmError> {
     let cipher = Cipher::aes_256_gcm();
 
     let block_size = cipher.block_size();
@@ -534,25 +534,25 @@ fn aes_256_gcm_decrypt(
 
     let mut decrypter = Crypter::new(cipher, Mode::Decrypt, key, Some(iv)).map_err(|ossl_err| {
         error!(?ossl_err);
-        HsmError::Aes256GcmConfig
+        TpmError::Aes256GcmConfig
     })?;
 
     decrypter.pad(true);
     decrypter.set_tag(tag).map_err(|ossl_err| {
         error!(?ossl_err);
-        HsmError::Aes256GcmConfig
+        TpmError::Aes256GcmConfig
     })?;
 
     let mut count = decrypter
         .update(input, &mut plaintext)
         .map_err(|ossl_err| {
             error!(?ossl_err);
-            HsmError::Aes256GcmDecrypt
+            TpmError::Aes256GcmDecrypt
         })?;
 
     count += decrypter.finalize(&mut plaintext).map_err(|ossl_err| {
         error!(?ossl_err);
-        HsmError::Aes256GcmDecrypt
+        TpmError::Aes256GcmDecrypt
     })?;
 
     plaintext.truncate(count);
@@ -562,20 +562,7 @@ fn aes_256_gcm_decrypt(
 
 #[cfg(test)]
 mod tests {
-    use super::{aes_256_gcm_decrypt, aes_256_gcm_encrypt, KeyAlgorithm, SoftHsm};
-    use crate::{AuthValue, Hsm};
-    use openssl::asn1::Asn1Time;
-    use openssl::bn::BigNum;
-    use openssl::ec::{EcGroup, EcKey};
-    use openssl::hash::MessageDigest;
-    use openssl::nid::Nid;
-    use openssl::pkey::{PKey, Private};
-    use openssl::sign::Verifier;
-    use openssl::x509::extension::{
-        BasicConstraints, ExtendedKeyUsage, KeyUsage, SubjectKeyIdentifier,
-    };
-    use openssl::x509::{X509NameBuilder, X509Req, X509};
-    use std::str::FromStr;
+    use super::{aes_256_gcm_decrypt, aes_256_gcm_encrypt, KeyAlgorithm, SoftTpm};
     use tracing::trace;
 
     #[test]
@@ -598,363 +585,33 @@ mod tests {
     #[test]
     fn soft_hmac_hw_bound() {
         let _ = tracing_subscriber::fmt::try_init();
-        // Create the Hsm.
-        let mut hsm = SoftHsm::new();
 
-        let auth_value =
-            AuthValue::from_str("Ohquiech9jis7Poo8Di7eth3").expect("Unable to create auth value");
+        let mut hsm_a = SoftTpm::new();
+        let mut hsm_b = SoftTpm::new();
 
-        // Request a new machine-key-context. This key "owns" anything
-        // created underneath it.
-        let loadable_machine_key = hsm
-            .machine_key_create(&auth_value)
-            .expect("Unable to create new machine key");
-
-        trace!(?loadable_machine_key);
-
-        let machine_key = hsm
-            .machine_key_load(&auth_value, &loadable_machine_key)
-            .expect("Unable to load machine key");
-
-        // from that ctx, create a hmac key.
-        let loadable_hmac_key = hsm
-            .hmac_key_create(&machine_key)
-            .expect("Unable to create new hmac key");
-
-        trace!(?loadable_hmac_key);
-
-        let hmac_key = hsm
-            .hmac_key_load(&machine_key, &loadable_hmac_key)
-            .expect("Unable to load hmac key");
-
-        // do a hmac.
-        let output_1 = hsm
-            .hmac(&hmac_key, &[0, 1, 2, 3])
-            .expect("Unable to perform hmac");
-
-        // destroy the Hsm
-        drop(hmac_key);
-        drop(machine_key);
-        drop(hsm);
-
-        // Make a new Hsm context.
-        let mut hsm = SoftHsm::new();
-
-        // Load the contexts.
-        let machine_key = hsm
-            .machine_key_load(&auth_value, &loadable_machine_key)
-            .expect("Unable to load machine key");
-
-        // Load the keys.
-        let hmac_key = hsm
-            .hmac_key_load(&machine_key, &loadable_hmac_key)
-            .expect("Unable to load hmac key");
-
-        // Do another hmac
-        let output_2 = hsm
-            .hmac(&hmac_key, &[0, 1, 2, 3])
-            .expect("Unable to perform hmac");
-
-        // It should be the same.
-        assert_eq!(output_1, output_2);
+        crate::test_tpm_hmac!(hsm_a, hsm_b);
     }
 
     #[test]
     fn soft_identity_ecdsa256_hw_bound() {
-        let _ = tracing_subscriber::fmt::try_init();
         // Create the Hsm.
-        let mut hsm = SoftHsm::new();
+        let mut hsm = SoftTpm::new();
 
-        let auth_value =
-            AuthValue::from_str("Ohquiech9jis7Poo8Di7eth3").expect("Unable to create auth value");
-
-        // Request a new machine-key-context. This key "owns" anything
-        // created underneath it.
-        let loadable_machine_key = hsm
-            .machine_key_create(&auth_value)
-            .expect("Unable to create new machine key");
-
-        trace!(?loadable_machine_key);
-
-        let machine_key = hsm
-            .machine_key_load(&auth_value, &loadable_machine_key)
-            .expect("Unable to load machine key");
-
-        // from that ctx, create an identity key
-        let loadable_id_key = hsm
-            .identity_key_create(&machine_key, KeyAlgorithm::Ecdsa256)
-            .expect("Unable to create id key");
-
-        trace!(?loadable_id_key);
-
-        let id_key = hsm
-            .identity_key_load(&machine_key, &loadable_id_key)
-            .expect("Unable to load id key");
-
-        let id_key_public_pem = hsm
-            .identity_key_public_as_pem(&id_key)
-            .expect("Unable to get id key public pem");
-
-        let pem_str = String::from_utf8_lossy(&id_key_public_pem);
-        trace!(?pem_str);
-
-        let id_key_public_der = hsm
-            .identity_key_public_as_der(&id_key)
-            .expect("Unable to get id key public pem");
-
-        // Rehydrate the der to a public key.
-
-        let public_key = PKey::public_key_from_der(&id_key_public_der).expect("Invalid DER");
-
-        let input = "test string";
-        let signature = hsm
-            .identity_key_sign(&id_key, input.as_bytes())
-            .expect("Unable to sign input");
-
-        let mut verifier =
-            Verifier::new(MessageDigest::sha256(), &public_key).expect("Unable to setup verifier.");
-
-        let valid = verifier
-            .verify_oneshot(&signature, input.as_bytes())
-            .expect("Unable to validate signature");
-
-        assert!(valid);
+        crate::test_tpm_identity!(hsm, KeyAlgorithm::Ecdsa256);
     }
 
     #[test]
     fn soft_identity_rsa2048_hw_bound() {
-        let _ = tracing_subscriber::fmt::try_init();
         // Create the Hsm.
-        let mut hsm = SoftHsm::new();
+        let mut hsm = SoftTpm::new();
 
-        let auth_value =
-            AuthValue::from_str("Ohquiech9jis7Poo8Di7eth3").expect("Unable to create auth value");
-
-        // Request a new machine-key-context. This key "owns" anything
-        // created underneath it.
-        let loadable_machine_key = hsm
-            .machine_key_create(&auth_value)
-            .expect("Unable to create new machine key");
-
-        trace!(?loadable_machine_key);
-
-        let machine_key = hsm
-            .machine_key_load(&auth_value, &loadable_machine_key)
-            .expect("Unable to load machine key");
-
-        // from that ctx, create an identity key
-        let loadable_id_key = hsm
-            .identity_key_create(&machine_key, KeyAlgorithm::Rsa2048)
-            .expect("Unable to create id key");
-
-        trace!(?loadable_id_key);
-
-        let id_key = hsm
-            .identity_key_load(&machine_key, &loadable_id_key)
-            .expect("Unable to load id key");
-
-        let id_key_public_pem = hsm
-            .identity_key_public_as_pem(&id_key)
-            .expect("Unable to get id key public pem");
-
-        let pem_str = String::from_utf8_lossy(&id_key_public_pem);
-        trace!(?pem_str);
-
-        let id_key_public_der = hsm
-            .identity_key_public_as_der(&id_key)
-            .expect("Unable to get id key public pem");
-
-        // Rehydrate the der to a public key.
-
-        let public_key = PKey::public_key_from_der(&id_key_public_der).expect("Invalid DER");
-
-        let input = "test string";
-        let signature = hsm
-            .identity_key_sign(&id_key, input.as_bytes())
-            .expect("Unable to sign input");
-
-        let mut verifier =
-            Verifier::new(MessageDigest::sha256(), &public_key).expect("Unable to setup verifier.");
-
-        let valid = verifier
-            .verify_oneshot(&signature, input.as_bytes())
-            .expect("Unable to validate signature");
-
-        assert!(valid);
-    }
-
-    fn create_ca() -> (PKey<Private>, X509) {
-        let ecgroup = EcGroup::from_curve_name(Nid::X9_62_PRIME256V1).unwrap();
-        let eckey = EcKey::generate(&ecgroup).unwrap();
-        let ca_key = PKey::from_ec_key(eckey).unwrap();
-
-        let mut x509_name = X509NameBuilder::new().unwrap();
-        x509_name
-            .append_entry_by_text("CN", "Dynamic Softtoken CA")
-            .unwrap();
-        let x509_name = x509_name.build();
-
-        let mut cert_builder = X509::builder().unwrap();
-        cert_builder.set_version(2).unwrap();
-
-        let serial_number = BigNum::from_u32(1)
-            .and_then(|serial| serial.to_asn1_integer())
-            .unwrap();
-        cert_builder.set_serial_number(&serial_number).unwrap();
-        cert_builder.set_subject_name(&x509_name).unwrap();
-        cert_builder.set_issuer_name(&x509_name).unwrap();
-
-        let not_before = Asn1Time::days_from_now(0).unwrap();
-        cert_builder.set_not_before(&not_before).unwrap();
-        let not_after = Asn1Time::days_from_now(1).unwrap();
-        cert_builder.set_not_after(&not_after).unwrap();
-
-        cert_builder
-            .append_extension(BasicConstraints::new().critical().ca().build().unwrap())
-            .unwrap();
-        cert_builder
-            .append_extension(
-                KeyUsage::new()
-                    .critical()
-                    .key_cert_sign()
-                    .crl_sign()
-                    .build()
-                    .unwrap(),
-            )
-            .unwrap();
-
-        let subject_key_identifier = SubjectKeyIdentifier::new()
-            .build(&cert_builder.x509v3_context(None, None))
-            .unwrap();
-        cert_builder
-            .append_extension(subject_key_identifier)
-            .unwrap();
-
-        cert_builder.set_pubkey(&ca_key).unwrap();
-
-        cert_builder.sign(&ca_key, MessageDigest::sha256()).unwrap();
-        let ca_cert = cert_builder.build();
-
-        (ca_key, ca_cert)
-    }
-
-    fn sign_request(req_der: &[u8], ca_key: &PKey<Private>, ca_cert: &X509) -> X509 {
-        let req = X509Req::from_der(req_der).unwrap();
-
-        let req_pkey = req.public_key().unwrap();
-        assert!(req.verify(&req_pkey).unwrap());
-
-        // depends on the ca, for a lot of them with machine id certs they ignore the values in
-        // the csr and stomp them with their own things.
-
-        let mut cert_builder = X509::builder().unwrap();
-        cert_builder.set_version(2).unwrap();
-
-        let serial_number = BigNum::from_u32(2)
-            .and_then(|serial| serial.to_asn1_integer())
-            .unwrap();
-        cert_builder.set_serial_number(&serial_number).unwrap();
-        cert_builder.set_subject_name(req.subject_name()).unwrap();
-        cert_builder
-            .set_issuer_name(ca_cert.subject_name())
-            .unwrap();
-
-        let not_before = Asn1Time::days_from_now(0).unwrap();
-        cert_builder.set_not_before(&not_before).unwrap();
-        let not_after = Asn1Time::days_from_now(1).unwrap();
-        cert_builder.set_not_after(&not_after).unwrap();
-
-        cert_builder
-            .append_extension(BasicConstraints::new().critical().build().unwrap())
-            .unwrap();
-
-        /*
-        cert_builder.append_extension(
-            KeyUsage::new()
-                .critical()
-                .digital_signature()
-                .key_encipherment()
-                .build().unwrap()
-        ).unwrap();
-
-        let subject_key_identifier = SubjectKeyIdentifier::new().build(&cert_builder.x509v3_context(None, None)).unwrap();
-        cert_builder.append_extension(subject_key_identifier).unwrap();
-        */
-
-        cert_builder
-            .append_extension(
-                ExtendedKeyUsage::new()
-                    // .server_auth()
-                    .client_auth()
-                    .build()
-                    .unwrap(),
-            )
-            .unwrap();
-
-        cert_builder.set_pubkey(&req_pkey).unwrap();
-
-        cert_builder.sign(&ca_key, MessageDigest::sha256()).unwrap();
-        cert_builder.build()
+        crate::test_tpm_identity!(hsm, KeyAlgorithm::Rsa2048);
     }
 
     #[test]
     fn soft_identity_ecdsa256_csr() {
-        let _ = tracing_subscriber::fmt::try_init();
-        // Create the Hsm.
-        let mut hsm = SoftHsm::new();
+        let mut hsm = SoftTpm::new();
 
-        let auth_value =
-            AuthValue::from_str("Ohquiech9jis7Poo8Di7eth3").expect("Unable to create auth value");
-
-        // Request a new machine-key-context. This key "owns" anything
-        // created underneath it.
-        let loadable_machine_key = hsm
-            .machine_key_create(&auth_value)
-            .expect("Unable to create new machine key");
-
-        trace!(?loadable_machine_key);
-
-        let machine_key = hsm
-            .machine_key_load(&auth_value, &loadable_machine_key)
-            .expect("Unable to load machine key");
-
-        // from that ctx, create an identity key
-        let loadable_id_key = hsm
-            .identity_key_create(&machine_key, KeyAlgorithm::Ecdsa256)
-            .expect("Unable to create id key");
-
-        trace!(?loadable_id_key);
-
-        // Get the CSR
-
-        let csr_der = hsm
-            .identity_key_certificate_request(&machine_key, &loadable_id_key, "common name")
-            .expect("Failed to create csr");
-
-        // Now, we need to sign this to an x509 cert externally.
-        let (ca_key, ca_cert) = create_ca();
-
-        let signed_cert = sign_request(&csr_der, &ca_key, &ca_cert);
-        trace!(
-            "{}",
-            String::from_utf8_lossy(signed_cert.to_text().unwrap().as_slice())
-        );
-
-        let signed_cert_der = signed_cert.to_der().unwrap();
-
-        let loadable_id_key = hsm
-            .identity_key_associate_certificate(&machine_key, &loadable_id_key, &signed_cert_der)
-            .unwrap();
-
-        // Now load it in:
-        let id_key = hsm
-            .identity_key_load(&machine_key, &loadable_id_key)
-            .expect("Unable to load id key");
-
-        let id_key_x509_pem = hsm
-            .identity_key_x509_as_pem(&id_key)
-            .expect("Unable to get id key public pem");
-
-        trace!("\n{}", String::from_utf8_lossy(&id_key_x509_pem));
+        crate::test_tpm_identity_csr!(hsm, KeyAlgorithm::Ecdsa256);
     }
 }

--- a/src/tpm.rs
+++ b/src/tpm.rs
@@ -106,7 +106,6 @@ impl TpmHsm {
 
 impl Hsm for TpmHsm {
     type MachineKey = TpmMachineKey;
-    type LoadableMachineKey = TpmLoadableMachineKey;
 
     type HmacKey = TpmHmacKey;
     type LoadableHmacKey = TpmLoadableHmacKey;
@@ -114,7 +113,7 @@ impl Hsm for TpmHsm {
     fn machine_key_create(
         &mut self,
         auth_value: &AuthValue,
-    ) -> Result<Self::LoadableMachineKey, HsmError> {
+    ) -> Result<LoadableMachineKey, HsmError> {
         // Setup the primary key.
         let primary = self.setup_owner_primary()?;
 

--- a/src/tpm.rs
+++ b/src/tpm.rs
@@ -1,6 +1,6 @@
 use crate::{
-    AuthValue, HmacKey, Hsm, HsmError, IdentityKey, KeyAlgorithm, LoadableHmacKey,
-    LoadableIdentityKey, LoadableMachineKey, MachineKey,
+    AuthValue, HmacKey, IdentityKey, KeyAlgorithm, LoadableHmacKey, LoadableIdentityKey,
+    LoadableMachineKey, MachineKey, Tpm, TpmError,
 };
 // use serde::{Deserialize, Serialize};
 use tracing::error;
@@ -20,23 +20,23 @@ pub use tss_esapi::handles::KeyHandle;
 pub use tss_esapi::structures::{Private, Public};
 pub use tss_esapi::TctiNameConf;
 
-pub struct TpmHsm {
+pub struct TpmTss {
     tpm_ctx: Context,
 }
 
-impl TpmHsm {
-    pub fn new(name_conf: TctiNameConf) -> Result<Self, HsmError> {
+impl TpmTss {
+    pub fn new(name_conf: TctiNameConf) -> Result<Self, TpmError> {
         Context::new(name_conf)
             .map_err(|tpm_err| {
                 error!(?tpm_err);
-                HsmError::TpmContextCreate
+                TpmError::TpmContextCreate
             })
-            .map(|tpm_ctx| TpmHsm { tpm_ctx })
+            .map(|tpm_ctx| TpmTss { tpm_ctx })
     }
 }
 
-impl TpmHsm {
-    fn setup_owner_primary(&mut self) -> Result<CreatePrimaryKeyResult, HsmError> {
+impl TpmTss {
+    fn setup_owner_primary(&mut self) -> Result<CreatePrimaryKeyResult, TpmError> {
         let object_attributes = ObjectAttributesBuilder::new()
             .with_fixed_tpm(true)
             .with_fixed_parent(true)
@@ -48,7 +48,7 @@ impl TpmHsm {
             .build()
             .map_err(|tpm_err| {
                 error!(?tpm_err);
-                HsmError::TpmPrimaryObjectAttributesInvalid
+                TpmError::TpmPrimaryObjectAttributesInvalid
             })?;
 
         let primary_pub = PublicBuilder::new()
@@ -62,7 +62,7 @@ impl TpmHsm {
             .build()
             .map_err(|tpm_err| {
                 error!(?tpm_err);
-                HsmError::TpmPrimaryPublicBuilderInvalid
+                TpmError::TpmPrimaryPublicBuilderInvalid
             })?;
 
         self.tpm_ctx
@@ -74,16 +74,16 @@ impl TpmHsm {
             })
             .map_err(|tpm_err| {
                 error!(?tpm_err);
-                HsmError::TpmPrimaryCreate
+                TpmError::TpmPrimaryCreate
             })
     }
 }
 
-impl Hsm for TpmHsm {
+impl Tpm for TpmTss {
     fn machine_key_create(
         &mut self,
         auth_value: &AuthValue,
-    ) -> Result<LoadableMachineKey, HsmError> {
+    ) -> Result<LoadableMachineKey, TpmError> {
         // Setup the primary key.
         let primary = self.setup_owner_primary()?;
 
@@ -94,7 +94,7 @@ impl Hsm for TpmHsm {
             .and_then(|random| Digest::try_from(random.as_slice()))
             .map_err(|tpm_err| {
                 error!(?tpm_err);
-                HsmError::TpmEntropy
+                TpmError::TpmEntropy
             })?;
 
         let object_attributes = ObjectAttributesBuilder::new()
@@ -109,7 +109,7 @@ impl Hsm for TpmHsm {
             .build()
             .map_err(|tpm_err| {
                 error!(?tpm_err);
-                HsmError::TpmMachineKeyObjectAttributesInvalid
+                TpmError::TpmMachineKeyObjectAttributesInvalid
             })?;
 
         let key_pub = PublicBuilder::new()
@@ -123,7 +123,7 @@ impl Hsm for TpmHsm {
             .build()
             .map_err(|tpm_err| {
                 error!(?tpm_err);
-                HsmError::TpmMachineKeyBuilderInvalid
+                TpmError::TpmMachineKeyBuilderInvalid
             })?;
 
         let tpm_auth_value = match auth_value {
@@ -131,7 +131,7 @@ impl Hsm for TpmHsm {
         }
         .map_err(|tpm_err| {
             error!(?tpm_err);
-            HsmError::TpmAuthValueInvalid
+            TpmError::TpmAuthValueInvalid
         })?;
 
         self.tpm_ctx
@@ -161,7 +161,7 @@ impl Hsm for TpmHsm {
             )
             .map_err(|tpm_err| {
                 error!(?tpm_err);
-                HsmError::TpmMachineKeyCreate
+                TpmError::TpmMachineKeyCreate
             })
 
         // Remember this isn't loaded and can't be used yet!
@@ -171,12 +171,12 @@ impl Hsm for TpmHsm {
         &mut self,
         auth_value: &AuthValue,
         loadable_key: &LoadableMachineKey,
-    ) -> Result<MachineKey, HsmError> {
+    ) -> Result<MachineKey, TpmError> {
         let (private, public) = match loadable_key {
             LoadableMachineKey::TpmAes128CfbV1 { private, public } => {
                 (private.clone(), public.clone())
             }
-            _ => return Err(HsmError::IncorrectKeyType),
+            _ => return Err(TpmError::IncorrectKeyType),
         };
 
         // Was this cleared in the former stages?
@@ -187,7 +187,7 @@ impl Hsm for TpmHsm {
         }
         .map_err(|tpm_err| {
             error!(?tpm_err);
-            HsmError::TpmAuthValueInvalid
+            TpmError::TpmAuthValueInvalid
         })?;
 
         self.tpm_ctx
@@ -206,14 +206,14 @@ impl Hsm for TpmHsm {
             .map(|key_handle| MachineKey::Tpm { key_handle })
             .map_err(|tpm_err| {
                 error!(?tpm_err);
-                HsmError::TpmMachineKeyLoad
+                TpmError::TpmMachineKeyLoad
             })
     }
 
-    fn hmac_key_create(&mut self, mk: &MachineKey) -> Result<LoadableHmacKey, HsmError> {
+    fn hmac_key_create(&mut self, mk: &MachineKey) -> Result<LoadableHmacKey, TpmError> {
         let mk_key_handle = match mk {
             MachineKey::Tpm { key_handle } => key_handle.clone(),
-            _ => return Err(HsmError::IncorrectKeyType),
+            _ => return Err(TpmError::IncorrectKeyType),
         };
 
         let unique_key_identifier = self
@@ -222,7 +222,7 @@ impl Hsm for TpmHsm {
             .and_then(|random| Digest::try_from(random.as_slice()))
             .map_err(|tpm_err| {
                 error!(?tpm_err);
-                HsmError::TpmEntropy
+                TpmError::TpmEntropy
             })?;
 
         let object_attributes = ObjectAttributesBuilder::new()
@@ -235,7 +235,7 @@ impl Hsm for TpmHsm {
             .build()
             .map_err(|tpm_err| {
                 error!(?tpm_err);
-                HsmError::TpmHmacKeyObjectAttributesInvalid
+                TpmError::TpmHmacKeyObjectAttributesInvalid
             })?;
 
         let key_pub = PublicBuilder::new()
@@ -249,7 +249,7 @@ impl Hsm for TpmHsm {
             .build()
             .map_err(|tpm_err| {
                 error!(?tpm_err);
-                HsmError::TpmHmacKeyBuilderInvalid
+                TpmError::TpmHmacKeyBuilderInvalid
             })?;
 
         self.tpm_ctx
@@ -267,7 +267,7 @@ impl Hsm for TpmHsm {
             )
             .map_err(|tpm_err| {
                 error!(?tpm_err);
-                HsmError::TpmHmacKeyCreate
+                TpmError::TpmHmacKeyCreate
             })
     }
 
@@ -275,15 +275,15 @@ impl Hsm for TpmHsm {
         &mut self,
         mk: &MachineKey,
         loadable_key: &LoadableHmacKey,
-    ) -> Result<HmacKey, HsmError> {
+    ) -> Result<HmacKey, TpmError> {
         let (private, public) = match loadable_key {
             LoadableHmacKey::TpmSha256V1 { private, public } => (private.clone(), public.clone()),
-            _ => return Err(HsmError::IncorrectKeyType),
+            _ => return Err(TpmError::IncorrectKeyType),
         };
 
         let mk_key_handle = match mk {
             MachineKey::Tpm { key_handle } => key_handle.clone(),
-            _ => return Err(HsmError::IncorrectKeyType),
+            _ => return Err(TpmError::IncorrectKeyType),
         };
 
         self.tpm_ctx
@@ -291,19 +291,19 @@ impl Hsm for TpmHsm {
             .map(|key_handle| HmacKey::TpmSha256 { key_handle })
             .map_err(|tpm_err| {
                 error!(?tpm_err);
-                HsmError::TpmHmacKeyLoad
+                TpmError::TpmHmacKeyLoad
             })
     }
 
-    fn hmac(&mut self, hk: &HmacKey, input: &[u8]) -> Result<Vec<u8>, HsmError> {
+    fn hmac(&mut self, hk: &HmacKey, input: &[u8]) -> Result<Vec<u8>, TpmError> {
         let (hk_key_handle, hk_alg) = match hk {
             HmacKey::TpmSha256 { key_handle } => (key_handle.clone(), HashingAlgorithm::Sha256),
-            _ => return Err(HsmError::IncorrectKeyType),
+            _ => return Err(TpmError::IncorrectKeyType),
         };
 
         let data_buffer = MaxBuffer::try_from(input).map_err(|tpm_err| {
             error!(?tpm_err);
-            HsmError::TpmHmacInputTooLarge
+            TpmError::TpmHmacInputTooLarge
         })?;
 
         self.tpm_ctx
@@ -313,7 +313,7 @@ impl Hsm for TpmHsm {
             .map(|digest| digest.value().to_vec())
             .map_err(|tpm_err| {
                 error!(?tpm_err);
-                HsmError::TpmHmacSign
+                TpmError::TpmHmacSign
             })
     }
 
@@ -321,24 +321,24 @@ impl Hsm for TpmHsm {
         &mut self,
         _mk: &MachineKey,
         _algorithm: KeyAlgorithm,
-    ) -> Result<LoadableIdentityKey, HsmError> {
-        Err(HsmError::TpmOperationUnsupported)
+    ) -> Result<LoadableIdentityKey, TpmError> {
+        Err(TpmError::TpmOperationUnsupported)
     }
 
     fn identity_key_load(
         &mut self,
         _mk: &MachineKey,
         _loadable_key: &LoadableIdentityKey,
-    ) -> Result<IdentityKey, HsmError> {
-        Err(HsmError::TpmOperationUnsupported)
+    ) -> Result<IdentityKey, TpmError> {
+        Err(TpmError::TpmOperationUnsupported)
     }
 
     fn identity_key_sign(
         &mut self,
         _key: &IdentityKey,
         _input: &[u8],
-    ) -> Result<Vec<u8>, HsmError> {
-        Err(HsmError::TpmOperationUnsupported)
+    ) -> Result<Vec<u8>, TpmError> {
+        Err(TpmError::TpmOperationUnsupported)
     }
 
     fn identity_key_certificate_request(
@@ -346,8 +346,8 @@ impl Hsm for TpmHsm {
         _mk: &MachineKey,
         _loadable_key: &LoadableIdentityKey,
         _cn: &str,
-    ) -> Result<Vec<u8>, HsmError> {
-        Err(HsmError::TpmOperationUnsupported)
+    ) -> Result<Vec<u8>, TpmError> {
+        Err(TpmError::TpmOperationUnsupported)
     }
 
     fn identity_key_associate_certificate(
@@ -355,33 +355,31 @@ impl Hsm for TpmHsm {
         _mk: &MachineKey,
         _loadable_key: &LoadableIdentityKey,
         _certificate_der: &[u8],
-    ) -> Result<LoadableIdentityKey, HsmError> {
-        Err(HsmError::TpmOperationUnsupported)
+    ) -> Result<LoadableIdentityKey, TpmError> {
+        Err(TpmError::TpmOperationUnsupported)
     }
 
-    fn identity_key_public_as_der(&mut self, _key: &IdentityKey) -> Result<Vec<u8>, HsmError> {
-        Err(HsmError::TpmOperationUnsupported)
+    fn identity_key_public_as_der(&mut self, _key: &IdentityKey) -> Result<Vec<u8>, TpmError> {
+        Err(TpmError::TpmOperationUnsupported)
     }
 
-    fn identity_key_public_as_pem(&mut self, _key: &IdentityKey) -> Result<Vec<u8>, HsmError> {
-        Err(HsmError::TpmOperationUnsupported)
+    fn identity_key_public_as_pem(&mut self, _key: &IdentityKey) -> Result<Vec<u8>, TpmError> {
+        Err(TpmError::TpmOperationUnsupported)
     }
 
-    fn identity_key_x509_as_pem(&mut self, _key: &IdentityKey) -> Result<Vec<u8>, HsmError> {
-        Err(HsmError::TpmOperationUnsupported)
+    fn identity_key_x509_as_pem(&mut self, _key: &IdentityKey) -> Result<Vec<u8>, TpmError> {
+        Err(TpmError::TpmOperationUnsupported)
     }
 
-    fn identity_key_x509_as_der(&mut self, _key: &IdentityKey) -> Result<Vec<u8>, HsmError> {
-        Err(HsmError::TpmOperationUnsupported)
+    fn identity_key_x509_as_der(&mut self, _key: &IdentityKey) -> Result<Vec<u8>, TpmError> {
+        Err(TpmError::TpmOperationUnsupported)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{TctiNameConf, TpmHsm};
-    use crate::{AuthValue, Hsm};
+    use super::{TctiNameConf, TpmTss};
     use std::str::FromStr;
-    use tracing::trace;
 
     #[test]
     fn tpm_hmac_hw_bound() {
@@ -391,63 +389,11 @@ mod tests {
             TctiNameConf::from_str("device:/dev/tpmrm0").expect("Failed to get TCTI");
 
         // Create the Hsm.
-        let mut hsm = TpmHsm::new(tpm_name_config.clone()).expect("Unable to build Tpm Context");
-
-        // Create a new random auth_value.
-        let auth_value = AuthValue::new_random().expect("Failed to generate new random secret");
-
-        // Request a new machine-key-context. This key "owns" anything
-        // created underneath it.
-        let loadable_machine_key = hsm
-            .machine_key_create(&auth_value)
-            .expect("Unable to create new machine key");
-
-        trace!(?loadable_machine_key);
-
-        let machine_key = hsm
-            .machine_key_load(&auth_value, &loadable_machine_key)
-            .expect("Unable to load machine key");
-
-        // from that ctx, create a hmac key.
-        let loadable_hmac_key = hsm
-            .hmac_key_create(&machine_key)
-            .expect("Unable to create new hmac key");
-
-        trace!(?loadable_hmac_key);
-
-        let hmac_key = hsm
-            .hmac_key_load(&machine_key, &loadable_hmac_key)
-            .expect("Unable to load hmac key");
-
-        // do a hmac.
-        let output_1 = hsm
-            .hmac(&hmac_key, &[0, 1, 2, 3])
-            .expect("Unable to perform hmac");
-
-        // destroy the Hsm
-        drop(hmac_key);
-        drop(machine_key);
-        drop(hsm);
+        let mut hsm_a = TpmTss::new(tpm_name_config.clone()).expect("Unable to build Tpm Context");
 
         // Make a new Hsm context.
-        let mut hsm = TpmHsm::new(tpm_name_config).expect("Unable to build Tpm Context");
+        let mut hsm_b = TpmTss::new(tpm_name_config).expect("Unable to build Tpm Context");
 
-        // Load the contexts.
-        let machine_key = hsm
-            .machine_key_load(&auth_value, &loadable_machine_key)
-            .expect("Unable to load machine key");
-
-        // Load the keys.
-        let hmac_key = hsm
-            .hmac_key_load(&machine_key, &loadable_hmac_key)
-            .expect("Unable to load hmac key");
-
-        // Do another hmac
-        let output_2 = hsm
-            .hmac(&hmac_key, &[0, 1, 2, 3])
-            .expect("Unable to perform hmac");
-
-        // It should be the same.
-        assert_eq!(output_1, output_2);
+        crate::test_tpm_hmac!(hsm_a, hsm_b);
     }
 }


### PR DESCRIPTION
WIP for the changes needed to integrate this to Kanidm's Unix Integration.

I'm not 100% sure about this. It feels "messy". I was trying to use the HSM trait for dynamic dispatch so that the Kani unix resolver didn't have to care about the type of hsm that was in use. But the issue there is we then need `Box<dyn Hsm<MachineKey = Type, LoadableMachineKey = Type, ....>>`. Effectively we end up in a really awkward spot if we use associated types.

This changes to use enums for runtime dynamic dispatch - currently I half-baked it, wrapping the types, but I feel we just probably need to flatten to one giant "MachineKey" enum and each HSM type pattern matches over it. Currently it's

```
#[derive(Debug, Clone, Serialize, Deserialize)]
pub enum LoadableMachineKey {
    Soft(soft::SoftLoadableMachineKey),
    #[cfg(feature = "tpm")]
    Tpm(tpm::TpmLoadableMachineKey),
    #[cfg(not(feature = "tpm"))]
    Tpm(()),
}
```

Flattened would be

```
#[derive(Debug, Clone, Serialize, Deserialize)]
pub enum LoadableMachineKey {
    SoftAes256GcmV1 {
        key: Vec<u8>,
        tag: [u8; 16],
        iv: [u8; 16],
    },
    #[cfg(feature = "tpm")]
    TpmAes128CfbV1 {
        private: TpmPrivate,
        public: TpmPublic,
    },
    #[cfg(not(feature = "tpm"))]
    TpmAes128CfbV1 {
        invalid: ()
    }
}
```

Maybe the design here is flawed? Maybe there is a better structure? The goal was that the resolvers would just get a "dyn Hsm" and be able to interact with it, so they don't need to care where their keys are, and they trust we did the work for them. 

I think to do this, maybe we just need to accept the enum's? Traits are making this too hard.

cc @micolous for some advice. 


## Checklist

- [ x ] This pr contains no AI generated code
- [ ] cargo fmt has been run
- [ ] cargo clippy has been run and there's no issues
- [ ] cargo test has been run and passes
