### PR TITLE
Add support for internal verification and key fingerprinting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kanidm-hsm-crypto"
 description = "A library for easily interacting with a HSM or TPM"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "MPL-2.0"
 homepage = "https://github.com/kanidm/hsm-crypto/"

--- a/src/tpm.rs
+++ b/src/tpm.rs
@@ -340,6 +340,10 @@ impl Tpm for TpmTss {
         Err(TpmError::TpmOperationUnsupported)
     }
 
+    fn identity_key_id(&mut self, _key: &IdentityKey) -> Result<Vec<u8>, TpmError> {
+        Err(TpmError::TpmOperationUnsupported)
+    }
+
     fn identity_key_sign(
         &mut self,
         _key: &IdentityKey,


### PR DESCRIPTION
This adds some minor changes required for compact-jwt to use this library as a cryptographic provider. 

## Checklist

- [ x ] This pr contains no AI generated code
- [ x ] cargo fmt has been run
- [ x ] cargo clippy has been run and there's no issues
- [ x ] cargo test has been run and passes
