### PR TITLE
Hex str

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kanidm-hsm-crypto"
 description = "A library for easily interacting with a HSM or TPM"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 license = "MPL-2.0"
 homepage = "https://github.com/kanidm/hsm-crypto/"
@@ -13,12 +13,13 @@ authors = ["William Brown <william@blackhats.net.au>"]
 tpm = ["dep:tss-esapi"]
 
 [dependencies]
+argon2 = { version = "0.5.2", features = ["alloc"] }
+hex = "0.4.3"
 openssl = "^0.10.57"
-tracing = "^0.1.37"
 serde = { version = "^1.0", features = ["derive"] }
+tracing = "^0.1.37"
 tss-esapi = { version = "^7.4.0", optional = true }
 zeroize = "1.6.0"
-argon2 = { version = "0.5.2", features = ["alloc"] }
 
 [dev-dependencies]
 tracing-subscriber = "^0.3.17"

--- a/src/tpm.rs
+++ b/src/tpm.rs
@@ -352,6 +352,15 @@ impl Tpm for TpmTss {
         Err(TpmError::TpmOperationUnsupported)
     }
 
+    fn identity_key_verify(
+        &mut self,
+        key: &IdentityKey,
+        input: &[u8],
+        signature: &[u8],
+    ) -> Result<bool, TpmError> {
+        Err(TpmError::TpmOperationUnsupported)
+    }
+
     fn identity_key_certificate_request(
         &mut self,
         _mk: &MachineKey,


### PR DESCRIPTION
Improves authValue to allow randomly generating hex-encoded pins. Changes from str to only accept hex encoded pins. 

## Checklist

- [ x ] This pr contains no AI generated code
- [ x ] cargo fmt has been run
- [ x ] cargo clippy has been run and there's no issues
- [ x ] cargo test has been run and passes
