### PR TITLE
Save tpm context space

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,7 +166,11 @@ pub enum TpmError {
     X509RequestSetPublic,
 
     TpmTctiNameInvalid,
+    TpmAuthSession,
     TpmContextCreate,
+    TpmContextFlushObject,
+    TpmContextSave,
+    TpmContextLoad,
     TpmPrimaryObjectAttributesInvalid,
     TpmPrimaryPublicBuilderInvalid,
     TpmPrimaryCreate,
@@ -246,7 +250,7 @@ pub enum HmacKey {
     },
     #[cfg(feature = "tpm")]
     TpmSha256 {
-        key_handle: tpm::KeyHandle,
+        key_context: tpm::TpmsContext,
     },
     #[cfg(not(feature = "tpm"))]
     TpmSha256 {
@@ -430,8 +434,14 @@ mod tests {
                 .hmac(&hmac_key, &[0, 1, 2, 3])
                 .expect("Unable to perform hmac");
 
+            // Show the context load/flush is okay.
+            let output_3 = $tpm_b
+                .hmac(&hmac_key, &[0, 1, 2, 3])
+                .expect("Unable to perform hmac");
+
             // It should be the same.
             assert_eq!(output_1, output_2);
+            assert_eq!(output_1, output_3);
         };
     }
 

--- a/src/tpm.rs
+++ b/src/tpm.rs
@@ -5,10 +5,12 @@ use crate::{
 // use serde::{Deserialize, Serialize};
 use tracing::error;
 
-use tss_esapi::attributes::ObjectAttributesBuilder;
+use tss_esapi::attributes::{ObjectAttributesBuilder, SessionAttributesBuilder};
+use tss_esapi::constants::SessionType;
 use tss_esapi::structures::{
     Auth, CreateKeyResult, CreatePrimaryKeyResult, Digest, KeyedHashScheme, MaxBuffer,
-    PublicBuilder, PublicKeyedHashParameters, SymmetricCipherParameters, SymmetricDefinitionObject,
+    PublicBuilder, PublicKeyedHashParameters, SymmetricCipherParameters, SymmetricDefinition,
+    SymmetricDefinitionObject,
 };
 use tss_esapi::Context;
 use tss_esapi::TctiNameConf;
@@ -16,14 +18,19 @@ use tss_esapi::TctiNameConf;
 use tss_esapi::interface_types::resource_handles::Hierarchy;
 
 use tss_esapi::interface_types::algorithm::{HashingAlgorithm, PublicAlgorithm};
+use tss_esapi::interface_types::session_handles::AuthSession;
+
+use tss_esapi::handles::ObjectHandle;
 
 pub use tss_esapi::handles::KeyHandle;
 pub use tss_esapi::structures::{Private, Public};
+pub use tss_esapi::utils::TpmsContext;
 
 use std::str::FromStr;
 
 pub struct TpmTss {
     tpm_ctx: Context,
+    _auth_session: AuthSession,
 }
 
 impl TpmTss {
@@ -33,12 +40,50 @@ impl TpmTss {
             TpmError::TpmTctiNameInvalid
         })?;
 
-        Context::new(tpm_name_config)
+        let mut tpm_ctx = Context::new(tpm_name_config).map_err(|tpm_err| {
+            error!(?tpm_err);
+            TpmError::TpmContextCreate
+        })?;
+
+        let maybe_auth_session = tpm_ctx
+            .start_auth_session(
+                None,
+                None,
+                None,
+                SessionType::Hmac,
+                SymmetricDefinition::AES_128_CFB,
+                HashingAlgorithm::Sha256,
+            )
             .map_err(|tpm_err| {
                 error!(?tpm_err);
-                TpmError::TpmContextCreate
-            })
-            .map(|tpm_ctx| TpmTss { tpm_ctx })
+                TpmError::TpmAuthSession
+            })?;
+
+        let auth_session = maybe_auth_session.ok_or_else(|| {
+            error!("No auth session created by tpm context");
+            TpmError::TpmAuthSession
+        })?;
+
+        let (session_attributes, session_attributes_mask) = SessionAttributesBuilder::new()
+            .with_decrypt(true)
+            .with_encrypt(true)
+            .build();
+
+        tpm_ctx
+            .tr_sess_set_attributes(auth_session, session_attributes, session_attributes_mask)
+            .map_err(|tpm_err| {
+                error!(?tpm_err);
+                TpmError::TpmAuthSession
+            })?;
+
+        let session_handles = (Some(auth_session), None, None);
+
+        tpm_ctx.set_sessions(session_handles);
+
+        Ok(TpmTss {
+            tpm_ctx,
+            _auth_session: auth_session,
+        })
     }
 }
 
@@ -84,6 +129,47 @@ impl TpmTss {
                 TpmError::TpmPrimaryCreate
             })
     }
+
+    fn execute_with_temporary_object<F, T>(
+        &mut self,
+        object: ObjectHandle,
+        f: F,
+    ) -> Result<T, TpmError>
+    where
+        F: FnOnce(&mut Self, ObjectHandle) -> Result<T, TpmError>,
+    {
+        let res = f(self, object);
+
+        self.tpm_ctx.flush_context(object).map_err(|tpm_err| {
+            error!(?tpm_err);
+            TpmError::TpmContextFlushObject
+        })?;
+
+        res
+    }
+
+    fn execute_with_temporary_object_context<F, T>(
+        &mut self,
+        tpms_context: TpmsContext,
+        f: F,
+    ) -> Result<T, TpmError>
+    where
+        F: FnOnce(&mut Self, ObjectHandle) -> Result<T, TpmError>,
+    {
+        let object = self.tpm_ctx.context_load(tpms_context).map_err(|tpm_err| {
+            error!(?tpm_err);
+            TpmError::TpmContextLoad
+        })?;
+
+        let res = f(self, object);
+
+        self.tpm_ctx.flush_context(object).map_err(|tpm_err| {
+            error!(?tpm_err);
+            TpmError::TpmContextFlushObject
+        })?;
+
+        res
+    }
 }
 
 impl Tpm for TpmTss {
@@ -94,82 +180,85 @@ impl Tpm for TpmTss {
         // Setup the primary key.
         let primary = self.setup_owner_primary()?;
 
-        // Create the Machine Key.
-        let unique_key_identifier = self
-            .tpm_ctx
-            .get_random(16)
-            .and_then(|random| Digest::try_from(random.as_slice()))
-            .map_err(|tpm_err| {
-                error!(?tpm_err);
-                TpmError::TpmEntropy
-            })?;
+        self.execute_with_temporary_object(
+            primary.key_handle.into(),
+            |hsm_ctx, primary_key_handle| {
+                // Create the Machine Key.
+                let unique_key_identifier = hsm_ctx
+                    .tpm_ctx
+                    .get_random(16)
+                    .and_then(|random| Digest::try_from(random.as_slice()))
+                    .map_err(|tpm_err| {
+                        error!(?tpm_err);
+                        TpmError::TpmEntropy
+                    })?;
 
-        let object_attributes = ObjectAttributesBuilder::new()
-            .with_fixed_tpm(true)
-            .with_fixed_parent(true)
-            .with_st_clear(false)
-            .with_sensitive_data_origin(true)
-            .with_user_with_auth(true)
-            .with_admin_with_policy(true)
-            .with_decrypt(true)
-            .with_restricted(true)
-            .build()
-            .map_err(|tpm_err| {
-                error!(?tpm_err);
-                TpmError::TpmMachineKeyObjectAttributesInvalid
-            })?;
+                let object_attributes = ObjectAttributesBuilder::new()
+                    .with_fixed_tpm(true)
+                    .with_fixed_parent(true)
+                    .with_st_clear(false)
+                    .with_sensitive_data_origin(true)
+                    .with_user_with_auth(true)
+                    .with_admin_with_policy(true)
+                    .with_decrypt(true)
+                    .with_restricted(true)
+                    .build()
+                    .map_err(|tpm_err| {
+                        error!(?tpm_err);
+                        TpmError::TpmMachineKeyObjectAttributesInvalid
+                    })?;
 
-        let key_pub = PublicBuilder::new()
-            .with_public_algorithm(PublicAlgorithm::SymCipher)
-            .with_name_hashing_algorithm(HashingAlgorithm::Sha256)
-            .with_object_attributes(object_attributes)
-            .with_symmetric_cipher_parameters(SymmetricCipherParameters::new(
-                SymmetricDefinitionObject::AES_128_CFB,
-            ))
-            .with_symmetric_cipher_unique_identifier(unique_key_identifier)
-            .build()
-            .map_err(|tpm_err| {
-                error!(?tpm_err);
-                TpmError::TpmMachineKeyBuilderInvalid
-            })?;
+                let key_pub = PublicBuilder::new()
+                    .with_public_algorithm(PublicAlgorithm::SymCipher)
+                    .with_name_hashing_algorithm(HashingAlgorithm::Sha256)
+                    .with_object_attributes(object_attributes)
+                    .with_symmetric_cipher_parameters(SymmetricCipherParameters::new(
+                        SymmetricDefinitionObject::AES_128_CFB,
+                    ))
+                    .with_symmetric_cipher_unique_identifier(unique_key_identifier)
+                    .build()
+                    .map_err(|tpm_err| {
+                        error!(?tpm_err);
+                        TpmError::TpmMachineKeyBuilderInvalid
+                    })?;
 
-        let tpm_auth_value = match auth_value {
-            AuthValue::Key256Bit { auth_key } => Auth::try_from(auth_key.as_ref()),
-        }
-        .map_err(|tpm_err| {
-            error!(?tpm_err);
-            TpmError::TpmAuthValueInvalid
-        })?;
+                let tpm_auth_value = match auth_value {
+                    AuthValue::Key256Bit { auth_key } => Auth::try_from(auth_key.as_ref()),
+                }
+                .map_err(|tpm_err| {
+                    error!(?tpm_err);
+                    TpmError::TpmAuthValueInvalid
+                })?;
 
-        self.tpm_ctx
-            .execute_with_nullauth_session(|ctx_outer| {
-                ctx_outer.execute_with_temporary_object(
-                    primary.key_handle.into(),
-                    |ctx, object_handle| {
+                hsm_ctx
+                    .tpm_ctx
+                    .execute_with_nullauth_session(|ctx| {
                         ctx.create(
-                            object_handle.into(),
+                            primary_key_handle.into(),
                             key_pub,
                             Some(tpm_auth_value),
                             None,
                             None,
                             None,
                         )
-                    },
-                )
-            })
-            .map(
-                |CreateKeyResult {
-                     out_private: private,
-                     out_public: public,
-                     creation_data: _,
-                     creation_hash: _,
-                     creation_ticket: _,
-                 }| { LoadableMachineKey::TpmAes128CfbV1 { private, public } },
-            )
-            .map_err(|tpm_err| {
-                error!(?tpm_err);
-                TpmError::TpmMachineKeyCreate
-            })
+                    })
+                    .map(
+                        |CreateKeyResult {
+                             out_private: private,
+                             out_public: public,
+                             creation_data: _,
+                             creation_hash: _,
+                             creation_ticket: _,
+                         }| {
+                            LoadableMachineKey::TpmAes128CfbV1 { private, public }
+                        },
+                    )
+                    .map_err(|tpm_err| {
+                        error!(?tpm_err);
+                        TpmError::TpmMachineKeyCreate
+                    })
+            },
+        )
 
         // Remember this isn't loaded and can't be used yet!
     }
@@ -189,32 +278,33 @@ impl Tpm for TpmTss {
         // Was this cleared in the former stages?
         let primary = self.setup_owner_primary()?;
 
-        let tpm_auth_value = match auth_value {
-            AuthValue::Key256Bit { auth_key } => Auth::try_from(auth_key.as_ref()),
-        }
-        .map_err(|tpm_err| {
-            error!(?tpm_err);
-            TpmError::TpmAuthValueInvalid
-        })?;
+        self.execute_with_temporary_object(
+            primary.key_handle.into(),
+            |hsm_ctx, primary_key_handle| {
+                let tpm_auth_value = match auth_value {
+                    AuthValue::Key256Bit { auth_key } => Auth::try_from(auth_key.as_ref()),
+                }
+                .map_err(|tpm_err| {
+                    error!(?tpm_err);
+                    TpmError::TpmAuthValueInvalid
+                })?;
 
-        self.tpm_ctx
-            .execute_with_nullauth_session(|ctx_outer| {
-                ctx_outer.execute_with_temporary_object(
-                    primary.key_handle.into(),
-                    |ctx, object_handle| {
-                        ctx.load(object_handle.into(), private.clone(), public.clone())
+                hsm_ctx
+                    .tpm_ctx
+                    .execute_with_nullauth_session(|ctx| {
+                        ctx.load(primary_key_handle.into(), private.clone(), public.clone())
                             .and_then(|key_handle| {
                                 ctx.tr_set_auth(key_handle.into(), tpm_auth_value)
                                     .map(|()| key_handle)
                             })
-                    },
-                )
-            })
-            .map(|key_handle| MachineKey::Tpm { key_handle })
-            .map_err(|tpm_err| {
-                error!(?tpm_err);
-                TpmError::TpmMachineKeyLoad
-            })
+                    })
+                    .map(|key_handle| MachineKey::Tpm { key_handle })
+                    .map_err(|tpm_err| {
+                        error!(?tpm_err);
+                        TpmError::TpmMachineKeyLoad
+                    })
+            },
+        )
     }
 
     fn hmac_key_create(&mut self, mk: &MachineKey) -> Result<LoadableHmacKey, TpmError> {
@@ -293,18 +383,31 @@ impl Tpm for TpmTss {
             _ => return Err(TpmError::IncorrectKeyType),
         };
 
-        self.tpm_ctx
+        let key_handle = self
+            .tpm_ctx
             .execute_with_nullauth_session(|ctx| ctx.load(mk_key_handle, private, public))
-            .map(|key_handle| HmacKey::TpmSha256 { key_handle })
             .map_err(|tpm_err| {
                 error!(?tpm_err);
                 TpmError::TpmHmacKeyLoad
-            })
+            })?;
+
+        // Now it's loaded, lets setup the context we will load/unload as needed. In this
+        // process we WILL be unloading the keyhandle.
+        self.execute_with_temporary_object(key_handle.into(), |hsm_ctx, hmac_key_handle| {
+            hsm_ctx
+                .tpm_ctx
+                .context_save(hmac_key_handle.into())
+                .map(|key_context| HmacKey::TpmSha256 { key_context })
+                .map_err(|tpm_err| {
+                    error!(?tpm_err);
+                    TpmError::TpmContextSave
+                })
+        })
     }
 
     fn hmac(&mut self, hk: &HmacKey, input: &[u8]) -> Result<Vec<u8>, TpmError> {
-        let (hk_key_handle, hk_alg) = match hk {
-            HmacKey::TpmSha256 { key_handle } => (key_handle.clone(), HashingAlgorithm::Sha256),
+        let (hk_key_context, hk_alg) = match hk {
+            HmacKey::TpmSha256 { key_context } => (key_context.clone(), HashingAlgorithm::Sha256),
             _ => return Err(TpmError::IncorrectKeyType),
         };
 
@@ -313,15 +416,16 @@ impl Tpm for TpmTss {
             TpmError::TpmHmacInputTooLarge
         })?;
 
-        self.tpm_ctx
-            .execute_with_nullauth_session(|ctx| {
-                ctx.hmac(hk_key_handle.into(), data_buffer, hk_alg)
-            })
-            .map(|digest| digest.value().to_vec())
-            .map_err(|tpm_err| {
-                error!(?tpm_err);
-                TpmError::TpmHmacSign
-            })
+        self.execute_with_temporary_object_context(hk_key_context, |hsm_ctx, key_handle| {
+            hsm_ctx
+                .tpm_ctx
+                .hmac(key_handle.into(), data_buffer, hk_alg)
+                .map(|digest| digest.value().to_vec())
+                .map_err(|tpm_err| {
+                    error!(?tpm_err);
+                    TpmError::TpmHmacSign
+                })
+        })
     }
 
     fn identity_key_create(
@@ -354,9 +458,9 @@ impl Tpm for TpmTss {
 
     fn identity_key_verify(
         &mut self,
-        key: &IdentityKey,
-        input: &[u8],
-        signature: &[u8],
+        _key: &IdentityKey,
+        _input: &[u8],
+        _signature: &[u8],
     ) -> Result<bool, TpmError> {
         Err(TpmError::TpmOperationUnsupported)
     }


### PR DESCRIPTION
Improve handling of auth sessions and the tpm context to ensure that we don't over-use the limited tpm memory. 

## Checklist

- [ x ] This pr contains no AI generated code
- [ x ] cargo fmt has been run
- [  ] cargo clippy has been run and there's no issues
-  [ x ] cargo test has been run and passes
