### PR TITLE
20231125 tpm context

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,8 @@ authors = ["William Brown <william@blackhats.net.au>"]
 # default = ["tpm"]
 tpm = ["dep:tss-esapi"]
 
+# tss-esapi = { path = "../rust-tss-esapi/tss-esapi" }
+
 [dependencies]
 argon2 = { version = "0.5.2", features = ["alloc"] }
 hex = "0.4.3"
@@ -23,3 +25,5 @@ zeroize = "1.6.0"
 
 [dev-dependencies]
 tracing-subscriber = "^0.3.17"
+
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,6 +195,21 @@ pub enum TpmError {
     TpmIdentityKeyAlgorithmInvalid,
     TpmIdentityKeyBuilderInvalid,
     TpmIdentityKeyCreate,
+    TpmIdentityKeySign,
+    TpmIdentityKeySignatureInvalid,
+    TpmIdentityKeyEcdsaSigRInvalid,
+    TpmIdentityKeyEcdsaSigSInvalid,
+    TpmIdentityKeyEcdsaSigFromParams,
+    TpmIdentityKeyEcdsaSigToDer,
+
+    TpmIdentityKeyParamInvalid,
+    TpmIdentityKeyParamsToRsaSig,
+
+    TpmIdentityKeyDerToEcdsaSig,
+    TpmIdentityKeyParamRInvalid,
+    TpmIdentityKeyParamSInvalid,
+    TpmIdentityKeyParamsToEcdsaSig,
+    TpmIdentityKeyVerify,
 
     TpmOperationUnsupported,
 
@@ -637,10 +652,14 @@ mod tests {
                 .identity_key_sign(&id_key, input.as_bytes())
                 .expect("Unable to sign input");
 
+            trace!(?signature);
+
+            let verify = $tpm.identity_key_verify(&id_key, input.as_bytes(), signature.as_slice());
+
+            trace!(?verify);
+
             // Internal verification
-            assert!($tpm
-                .identity_key_verify(&id_key, input.as_bytes(), signature.as_slice())
-                .expect("Unable to sign input"));
+            assert!(verify.expect("Unable to sign input"));
         };
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -260,7 +260,7 @@ pub enum HmacKey {
     },
     #[cfg(not(feature = "tpm"))]
     TpmSha256 {
-        key_handle: (),
+        key_context: (),
     },
 }
 
@@ -312,14 +312,14 @@ pub enum IdentityKey {
         x509: Option<X509>,
     },
     #[cfg(not(feature = "tpm"))]
-    TpmEcdsa256 { key_handle: (), x509: () },
+    TpmEcdsa256 { key_context: (), x509: () },
     #[cfg(feature = "tpm")]
     TpmRsa2048 {
         key_context: tpm::TpmsContext,
         x509: Option<X509>,
     },
     #[cfg(not(feature = "tpm"))]
-    TpmRsa2048 { key_handle: (), x509: () },
+    TpmRsa2048 { key_context: (), x509: () },
 }
 
 impl IdentityKey {

--- a/src/soft.rs
+++ b/src/soft.rs
@@ -327,6 +327,9 @@ impl Tpm for SoftTpm {
                     TpmError::IdentityKeyPublicToDer
                 })
             }
+            IdentityKey::TpmEcdsa256 { .. } | IdentityKey::TpmRsa2048 { .. } => {
+                Err(TpmError::IncorrectKeyType)
+            }
         }
     }
 
@@ -338,6 +341,9 @@ impl Tpm for SoftTpm {
                     error!(?ossl_err);
                     TpmError::IdentityKeyPublicToPem
                 })
+            }
+            IdentityKey::TpmEcdsa256 { .. } | IdentityKey::TpmRsa2048 { .. } => {
+                Err(TpmError::IncorrectKeyType)
             }
         }
     }
@@ -355,6 +361,9 @@ impl Tpm for SoftTpm {
                 error!(?ossl_err);
                 TpmError::IdentityKeyX509ToPem
             }),
+            IdentityKey::TpmEcdsa256 { .. } | IdentityKey::TpmRsa2048 { .. } => {
+                Err(TpmError::IncorrectKeyType)
+            }
             _ => Err(TpmError::IdentityKeyX509Missing),
         }
     }
@@ -372,6 +381,9 @@ impl Tpm for SoftTpm {
                 error!(?ossl_err);
                 TpmError::IdentityKeyX509ToDer
             }),
+            IdentityKey::TpmEcdsa256 { .. } | IdentityKey::TpmRsa2048 { .. } => {
+                Err(TpmError::IncorrectKeyType)
+            }
             _ => Err(TpmError::IdentityKeyX509Missing),
         }
     }
@@ -384,6 +396,9 @@ impl Tpm for SoftTpm {
                     error!(?ossl_err);
                     TpmError::IdentityKeyInvalidForSigning
                 })?
+            }
+            IdentityKey::TpmEcdsa256 { .. } | IdentityKey::TpmRsa2048 { .. } => {
+                return Err(TpmError::IncorrectKeyType)
             }
         };
 
@@ -406,6 +421,9 @@ impl Tpm for SoftTpm {
                     error!(?ossl_err);
                     TpmError::IdentityKeyInvalidForVerification
                 })?
+            }
+            IdentityKey::TpmEcdsa256 { .. } | IdentityKey::TpmRsa2048 { .. } => {
+                return Err(TpmError::IncorrectKeyType)
             }
         };
 
@@ -465,6 +483,9 @@ impl Tpm for SoftTpm {
                         TpmError::X509RequestSign
                     })?;
             }
+            IdentityKey::TpmEcdsa256 { .. } | IdentityKey::TpmRsa2048 { .. } => {
+                return Err(TpmError::IncorrectKeyType)
+            }
         }
 
         req_builder.build().to_der().map_err(|ossl_err| {
@@ -499,6 +520,9 @@ impl Tpm for SoftTpm {
                     return Err(TpmError::X509KeyMismatch);
                 }
             }
+            IdentityKey::TpmEcdsa256 { .. } | IdentityKey::TpmRsa2048 { .. } => {
+                return Err(TpmError::IncorrectKeyType)
+            }
         };
 
         // At this point we know the cert belongs to this key, so lets
@@ -513,6 +537,8 @@ impl Tpm for SoftTpm {
             LoadableIdentityKey::SoftRsa2048V1 { ref mut x509, .. } => {
                 *x509 = Some(certificate_der.to_vec());
             }
+            LoadableIdentityKey::TpmEcdsa256V1 { .. }
+            | LoadableIdentityKey::TpmRsa2048V1 { .. } => return Err(TpmError::IncorrectKeyType),
         };
 
         Ok(cloned_key)

--- a/src/soft.rs
+++ b/src/soft.rs
@@ -402,10 +402,18 @@ impl Tpm for SoftTpm {
             }
         };
 
-        signer.sign_oneshot_to_vec(input).map_err(|ossl_err| {
-            error!(?ossl_err);
-            TpmError::IdentityKeySignature
-        })
+        signer
+            .sign_oneshot_to_vec(input)
+            .map_err(|ossl_err| {
+                error!(?ossl_err);
+                TpmError::IdentityKeySignature
+            })
+            .map(|sig| {
+                let res = openssl::ecdsa::EcdsaSig::from_der(&sig);
+                tracing::debug!(res = %res.is_ok());
+
+                sig
+            })
     }
 
     fn identity_key_verify(

--- a/src/tpm.rs
+++ b/src/tpm.rs
@@ -598,7 +598,10 @@ impl Tpm for TpmTss {
         _key: &IdentityKey,
         _input: &[u8],
     ) -> Result<Vec<u8>, TpmError> {
+        // Waiting on https://github.com/parallaxsecond/rust-tss-esapi/pull/476
+
         Err(TpmError::TpmOperationUnsupported)
+
     }
 
     fn identity_key_verify(
@@ -671,7 +674,7 @@ mod tests {
     }
 
     #[test]
-    fn soft_identity_rsa2048_hw_bound() {
+    fn tpm_identity_rsa2048_hw_bound() {
         // Create the Hsm.
         let mut hsm = TpmTss::new("device:/dev/tpmrm0").expect("Unable to build Tpm Context");
 


### PR DESCRIPTION
This makes TPM contexts more efficient at run time with higher numbers of keys. Needing to wait on upstream before we can do id key sign here though. 

## Checklist

- [ x ] This pr contains no AI generated code
- [ x ] cargo fmt has been run
- [ ] cargo clippy has been run and there's no issues
- [ ] cargo test has been run and passes
