### PR TITLE
Migrate tss-esapi to v8 to access serde features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,8 @@ hex = "0.4.3"
 openssl = "^0.10.57"
 serde = { version = "^1.0", features = ["derive"] }
 tracing = "^0.1.37"
-tss-esapi = { version = "^7.4.0", optional = true }
+# tss-esapi = { version = "^7.4.0", optional = true }
+tss-esapi = { git = "https://github.com/parallaxsecond/rust-tss-esapi.git", rev = "8cc11fc76838f70557248c968faaaad3050fcbc3", optional = true }
 zeroize = "1.6.0"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ authors = ["William Brown <william@blackhats.net.au>"]
 
 [features]
 # default = ["tpm"]
-tpm = ["dep:tss-esapi"]
+tpm = ["dep:tss-esapi", "dep:tss-esapi-sys"]
 
 # tss-esapi = { path = "../rust-tss-esapi/tss-esapi" }
 
@@ -20,8 +20,8 @@ hex = "0.4.3"
 openssl = "^0.10.57"
 serde = { version = "^1.0", features = ["derive"] }
 tracing = "^0.1.37"
-# tss-esapi = { version = "^7.4.0", optional = true }
-tss-esapi = { git = "https://github.com/parallaxsecond/rust-tss-esapi.git", rev = "8cc11fc76838f70557248c968faaaad3050fcbc3", optional = true }
+tss-esapi-sys = { version = "0.5.0", optional = true, features = ["generate-bindings"] }
+tss-esapi = { version = "=8.0.0-alpha", optional = true }
 zeroize = "1.6.0"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,12 +19,10 @@
 use argon2::MIN_SALT_LEN;
 use openssl::pkey::{PKey, Private};
 use openssl::x509::X509;
+use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use tracing::error;
 use zeroize::Zeroizing;
-
-#[cfg(not(feature = "tpm"))]
-use serde::{Deserialize, Serialize};
 
 pub mod soft;
 
@@ -217,8 +215,7 @@ pub enum TpmError {
     IncorrectKeyType,
 }
 
-#[derive(Debug, Clone)]
-#[cfg_attr(not(feature = "tpm"), derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum LoadableMachineKey {
     SoftAes256GcmV1 {
         key: Vec<u8>,
@@ -248,8 +245,7 @@ pub enum MachineKey {
     },
 }
 
-#[derive(Debug, Clone)]
-#[cfg_attr(not(feature = "tpm"), derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum LoadableHmacKey {
     SoftSha256V1 {
         key: Vec<u8>,
@@ -279,8 +275,7 @@ pub enum HmacKey {
     },
 }
 
-#[derive(Debug, Clone)]
-#[cfg_attr(not(feature = "tpm"), derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum LoadableIdentityKey {
     SoftEcdsa256V1 {
         key: Vec<u8>,

--- a/src/tpm.rs
+++ b/src/tpm.rs
@@ -198,7 +198,7 @@ impl Tpm for TpmTss {
                 let unique_key_identifier = hsm_ctx
                     .tpm_ctx
                     .get_random(16)
-                    .and_then(|random| Digest::try_from(random.as_slice()))
+                    .and_then(|random| Digest::from_bytes(random.as_slice()))
                     .map_err(|tpm_err| {
                         error!(?tpm_err);
                         TpmError::TpmEntropy
@@ -234,7 +234,7 @@ impl Tpm for TpmTss {
                     })?;
 
                 let tpm_auth_value = match auth_value {
-                    AuthValue::Key256Bit { auth_key } => Auth::try_from(auth_key.as_ref()),
+                    AuthValue::Key256Bit { auth_key } => Auth::from_bytes(auth_key.as_ref()),
                 }
                 .map_err(|tpm_err| {
                     error!(?tpm_err);
@@ -291,7 +291,7 @@ impl Tpm for TpmTss {
             primary.key_handle.into(),
             |hsm_ctx, primary_key_handle| {
                 let tpm_auth_value = match auth_value {
-                    AuthValue::Key256Bit { auth_key } => Auth::try_from(auth_key.as_ref()),
+                    AuthValue::Key256Bit { auth_key } => Auth::from_bytes(auth_key.as_ref()),
                 }
                 .map_err(|tpm_err| {
                     error!(?tpm_err);
@@ -325,7 +325,7 @@ impl Tpm for TpmTss {
         let unique_key_identifier = self
             .tpm_ctx
             .get_random(16)
-            .and_then(|random| Digest::try_from(random.as_slice()))
+            .and_then(|random| Digest::from_bytes(random.as_slice()))
             .map_err(|tpm_err| {
                 error!(?tpm_err);
                 TpmError::TpmEntropy
@@ -418,7 +418,7 @@ impl Tpm for TpmTss {
             _ => return Err(TpmError::IncorrectKeyType),
         };
 
-        let data_buffer = MaxBuffer::try_from(input).map_err(|tpm_err| {
+        let data_buffer = MaxBuffer::from_bytes(input).map_err(|tpm_err| {
             error!(?tpm_err);
             TpmError::TpmHmacInputTooLarge
         })?;
@@ -427,7 +427,7 @@ impl Tpm for TpmTss {
             hsm_ctx
                 .tpm_ctx
                 .hmac(key_handle.into(), data_buffer, hk_alg)
-                .map(|digest| digest.value().to_vec())
+                .map(|digest| digest.as_bytes().to_vec())
                 .map_err(|tpm_err| {
                     error!(?tpm_err);
                     TpmError::TpmHmacSign
@@ -652,7 +652,7 @@ impl Tpm for TpmTss {
             TpmError::IdentityKeyDigest
         })?;
 
-        let tpm_digest: Digest = Digest::try_from(&bytes as &[u8]).map_err(|tpm_err| {
+        let tpm_digest: Digest = Digest::from_bytes(&bytes as &[u8]).map_err(|tpm_err| {
             error!(?tpm_err);
             TpmError::IdentityKeyDigest
         })?;
@@ -752,7 +752,7 @@ impl Tpm for TpmTss {
                 key_context,
                 x509: _,
             } => {
-                let pk_rsa = PublicKeyRsa::try_from(signature).map_err(|tpm_err| {
+                let pk_rsa = PublicKeyRsa::from_bytes(signature).map_err(|tpm_err| {
                     error!(?tpm_err);
                     TpmError::TpmIdentityKeyParamInvalid
                 })?;
@@ -775,7 +775,7 @@ impl Tpm for TpmTss {
             TpmError::IdentityKeyDigest
         })?;
 
-        let tpm_digest: Digest = Digest::try_from(&bytes as &[u8]).map_err(|tpm_err| {
+        let tpm_digest: Digest = Digest::from_bytes(&bytes as &[u8]).map_err(|tpm_err| {
             error!(?tpm_err);
             TpmError::IdentityKeyDigest
         })?;


### PR DESCRIPTION
We require the serde features so that we can store the public/private parts of keys when a hardware TPM is in use. V8 also has a number of other changes we will require soon such at fixes for attestation.

## Checklist

- [ x ] This pr contains no AI generated code
- [ x ] cargo fmt has been run
- [ x ] cargo clippy has been run and there's no issues
- [ x ] cargo test has been run and passes
