### PR TITLE
Progress on MS extension support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,6 @@ authors = ["William Brown <william@blackhats.net.au>"]
 tpm = ["dep:tss-esapi", "dep:tss-esapi-sys"]
 msextensions = []
 
-# tss-esapi = { path = "../rust-tss-esapi/tss-esapi" }
-
 [dependencies]
 argon2 = { version = "0.5.2", features = ["alloc"] }
 hex = "0.4.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ authors = ["William Brown <william@blackhats.net.au>"]
 [features]
 # default = ["tpm"]
 tpm = ["dep:tss-esapi", "dep:tss-esapi-sys"]
+msextensions = []
 
 # tss-esapi = { path = "../rust-tss-esapi/tss-esapi" }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,12 +18,14 @@
 
 use argon2::MIN_SALT_LEN;
 use openssl::pkey::{PKey, Private};
-use openssl::rsa::Rsa;
 use openssl::x509::X509;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use tracing::error;
 use zeroize::Zeroizing;
+
+#[cfg(feature = "msextensions")]
+use openssl::rsa::Rsa;
 
 pub(crate) const AES256GCM_KEY_LEN: usize = 32;
 pub(crate) const HMAC_KEY_LEN: usize = 32;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,8 +263,8 @@ pub enum MachineKey {
     },
     #[cfg(feature = "tpm")]
     Tpm {
-        // key_handle: tpm::KeyHandle,
         key_context: tpm::TpmsContext,
+        auth_value: tpm::Auth,
     },
     #[cfg(not(feature = "tpm"))]
     Tpm {
@@ -1175,6 +1175,8 @@ mod ms_extn_tests {
             let machine_key = $tpm_a
                 .machine_key_load(&auth_value, &loadable_machine_key)
                 .expect("Unable to load machine key");
+
+            trace!("mk loaded");
 
             // from that ctx, create a hmac key.
             let loadable_ms_rsa_key = $tpm_a

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -218,6 +218,7 @@ pub enum TpmError {
     TpmIdentityKeyBuilderInvalid,
     TpmIdentityKeyCreate,
     TpmIdentityKeySign,
+    TpmIdentityKeyId,
     TpmIdentityKeySignatureInvalid,
     TpmIdentityKeyEcdsaSigRInvalid,
     TpmIdentityKeyEcdsaSigSInvalid,

--- a/src/soft.rs
+++ b/src/soft.rs
@@ -1,8 +1,11 @@
 use crate::{
     AuthValue, HmacKey, IdentityKey, KeyAlgorithm, LoadableHmacKey, LoadableIdentityKey,
-    LoadableMachineKey, MachineKey, Tpm, TpmError,
+    LoadableMachineKey, MachineKey, Tpm, TpmError, AES256GCM_KEY_LEN, HMAC_KEY_LEN,
 };
 use zeroize::Zeroizing;
+
+#[cfg(feature = "msextensions")]
+use crate::{LoadableMsOapxbcRsaKey, LoadableMsOapxbcSessionKey, MsOapxbcRsaKey};
 
 use openssl::ec::{EcGroup, EcKey};
 use openssl::hash::{hash, MessageDigest};
@@ -31,7 +34,7 @@ impl Tpm for SoftTpm {
         auth_value: &AuthValue,
     ) -> Result<LoadableMachineKey, TpmError> {
         // Create a "machine binding" key.
-        let mut buf = Zeroizing::new([0; 32]);
+        let mut buf = Zeroizing::new([0; AES256GCM_KEY_LEN]);
         rand_bytes(buf.as_mut()).map_err(|ossl_err| {
             error!(?ossl_err);
             TpmError::Entropy
@@ -72,7 +75,7 @@ impl Tpm for SoftTpm {
     }
 
     fn hmac_key_create(&mut self, mk: &MachineKey) -> Result<LoadableHmacKey, TpmError> {
-        let mut buf = Zeroizing::new([0; 32]);
+        let mut buf = Zeroizing::new([0; HMAC_KEY_LEN]);
         rand_bytes(buf.as_mut()).map_err(|ossl_err| {
             error!(?ossl_err);
             TpmError::Entropy
@@ -551,6 +554,266 @@ impl Tpm for SoftTpm {
 
         Ok(cloned_key)
     }
+
+    #[cfg(feature = "msextensions")]
+    fn msoapxbc_rsa_key_create(
+        &mut self,
+        mk: &MachineKey,
+    ) -> Result<LoadableMsOapxbcRsaKey, TpmError> {
+        let rsa = Rsa::generate(2048).map_err(|ossl_err| {
+            error!(?ossl_err);
+            TpmError::RsaGenerate
+        })?;
+
+        self.msoapxbc_rsa_key_import(mk, rsa)
+    }
+
+    #[cfg(feature = "msextensions")]
+    fn msoapxbc_rsa_key_import(
+        &mut self,
+        mk: &MachineKey,
+        private_key: Rsa<openssl::pkey::Private>,
+    ) -> Result<LoadableMsOapxbcRsaKey, TpmError> {
+        // Create our AES GCM key as well. This lets us encrypt "against" the
+        // RSA key here. For real TPM's we'll be using seal/unseal against the
+        // keyhandle as a parent.
+        let mut buf = Zeroizing::new([0; AES256GCM_KEY_LEN]);
+        rand_bytes(buf.as_mut()).map_err(|ossl_err| {
+            error!(?ossl_err);
+            TpmError::Entropy
+        })?;
+
+        let cek = rsa_oaep_encrypt(&private_key, buf.as_ref())?;
+
+        let der = private_key
+            .private_key_to_der()
+            .map(Zeroizing::new)
+            .map_err(|ossl_err| {
+                error!(?ossl_err);
+                TpmError::RsaPrivateToDer
+            })?;
+
+        let mut iv = [0; 16];
+        rand_bytes(&mut iv).map_err(|ossl_err| {
+            error!(?ossl_err);
+            TpmError::Entropy
+        })?;
+
+        let (key, tag) = match mk {
+            MachineKey::SoftAes256Gcm { key } => {
+                aes_256_gcm_encrypt(der.as_ref(), key.as_ref(), &iv)?
+            }
+            MachineKey::Tpm { .. } => return Err(TpmError::IncorrectKeyType),
+        };
+
+        Ok(LoadableMsOapxbcRsaKey::Soft2048V1 { key, tag, iv, cek })
+    }
+
+    #[cfg(feature = "msextensions")]
+    fn msoapxbc_rsa_key_load(
+        &mut self,
+        mk: &MachineKey,
+        loadable_key: &LoadableMsOapxbcRsaKey,
+    ) -> Result<MsOapxbcRsaKey, TpmError> {
+        match (mk, loadable_key) {
+            (
+                MachineKey::SoftAes256Gcm { key: mk_key },
+                LoadableMsOapxbcRsaKey::Soft2048V1 { key, tag, iv, cek },
+            ) => {
+                let key_der = aes_256_gcm_decrypt(key, tag, mk_key.as_ref(), iv)?;
+
+                let key = Rsa::private_key_from_der(key_der.as_ref()).map_err(|ossl_err| {
+                    error!(?ossl_err);
+                    TpmError::RsaKeyFromDer
+                })?;
+
+                let mut cek = rsa_oaep_decrypt(&key, &cek)?;
+
+                cek.truncate(AES256GCM_KEY_LEN);
+
+                Ok(MsOapxbcRsaKey::Soft { key, cek })
+            }
+            (_, _) => Err(TpmError::IncorrectKeyType),
+        }
+    }
+
+    #[cfg(feature = "msextensions")]
+    fn msoapxbc_rsa_public_as_der(&mut self, key: &MsOapxbcRsaKey) -> Result<Vec<u8>, TpmError> {
+        match key {
+            MsOapxbcRsaKey::Soft { key, cek: _ } => key.public_key_to_der().map_err(|ossl_err| {
+                error!(?ossl_err);
+                TpmError::MsOapxbcKeyPublicToDer
+            }),
+            _ => Err(TpmError::IncorrectKeyType),
+        }
+    }
+
+    #[cfg(feature = "msextensions")]
+    fn msoapxbc_rsa_decipher_session_key(
+        &mut self,
+        key: &MsOapxbcRsaKey,
+        input: &[u8],
+        expected_key_len: usize,
+    ) -> Result<LoadableMsOapxbcSessionKey, TpmError> {
+        match key {
+            MsOapxbcRsaKey::Soft { key, cek } => {
+                let mut unwrapped_key = rsa_oaep_decrypt(key, input)?;
+
+                unwrapped_key.truncate(expected_key_len);
+
+                // Bind to the parent.
+                let mut iv = [0; 16];
+                rand_bytes(&mut iv).map_err(|ossl_err| {
+                    error!(?ossl_err);
+                    TpmError::Entropy
+                })?;
+
+                eprintln!("{:?}", cek);
+
+                let (enc_session_key, tag) =
+                    aes_256_gcm_encrypt(unwrapped_key.as_ref(), cek.as_ref(), &iv)?;
+
+                // Return it in it's loadable form.
+                Ok(LoadableMsOapxbcSessionKey::SoftV1 {
+                    key: enc_session_key,
+                    tag,
+                    iv,
+                })
+            }
+            _ => Err(TpmError::IncorrectKeyType),
+        }
+    }
+
+    #[cfg(feature = "msextensions")]
+    fn msoapxbc_rsa_yield_session_key(
+        &mut self,
+        key: &MsOapxbcRsaKey,
+        session_key: &LoadableMsOapxbcSessionKey,
+    ) -> Result<Zeroizing<Vec<u8>>, TpmError> {
+        match (key, session_key) {
+            (
+                MsOapxbcRsaKey::Soft { key: _, cek },
+                LoadableMsOapxbcSessionKey::SoftV1 { key, tag, iv },
+            ) => aes_256_gcm_decrypt(key, tag, cek, iv),
+            (_, _) => Err(TpmError::IncorrectKeyType),
+        }
+    }
+}
+
+fn rsa_oaep_encrypt(
+    key: &Rsa<openssl::pkey::Private>,
+    key_to_wrap: &[u8],
+) -> Result<Vec<u8>, TpmError> {
+    use openssl::encrypt::Encrypter;
+    use openssl::rsa::Padding;
+
+    let rsa_pub_key = PKey::from_rsa(key.clone()).map_err(|ossl_err| {
+        error!(?ossl_err);
+        TpmError::MsOapxbcKeyOaepOption
+    })?;
+
+    let mut wrap_key_encrypter = Encrypter::new(&rsa_pub_key).map_err(|ossl_err| {
+        error!(?ossl_err);
+        TpmError::MsOapxbcKeyOaepOption
+    })?;
+
+    wrap_key_encrypter
+        .set_rsa_padding(Padding::PKCS1_OAEP)
+        .map_err(|ossl_err| {
+            error!(?ossl_err);
+            TpmError::MsOapxbcKeyOaepOption
+        })?;
+
+    wrap_key_encrypter
+        .set_rsa_mgf1_md(MessageDigest::sha1())
+        .map_err(|ossl_err| {
+            error!(?ossl_err);
+            TpmError::MsOapxbcKeyOaepOption
+        })?;
+
+    wrap_key_encrypter
+        .set_rsa_oaep_md(MessageDigest::sha1())
+        .map_err(|ossl_err| {
+            error!(?ossl_err);
+            TpmError::MsOapxbcKeyOaepOption
+        })?;
+
+    let buf_len = wrap_key_encrypter
+        .encrypt_len(key_to_wrap)
+        .map_err(|ossl_err| {
+            error!(?ossl_err);
+            TpmError::MsOapxbcKeyOaepEncipher
+        })?;
+
+    let mut wrapped_key = vec![0; buf_len];
+
+    let encoded_len = wrap_key_encrypter
+        .encrypt(key_to_wrap, wrapped_key.as_mut())
+        .map_err(|ossl_err| {
+            error!(?ossl_err);
+            TpmError::MsOapxbcKeyOaepEncipher
+        })?;
+
+    wrapped_key.truncate(encoded_len);
+
+    Ok(wrapped_key)
+}
+
+fn rsa_oaep_decrypt(
+    key: &Rsa<openssl::pkey::Private>,
+    input: &[u8],
+) -> Result<Zeroizing<Vec<u8>>, TpmError> {
+    use openssl::encrypt::Decrypter;
+    use openssl::rsa::Padding;
+
+    let rsa_priv_key = PKey::from_rsa(key.clone()).map_err(|ossl_err| {
+        error!(?ossl_err);
+        TpmError::MsOapxbcKeyOaepOption
+    })?;
+
+    let mut wrap_key_decrypter = Decrypter::new(&rsa_priv_key).map_err(|ossl_err| {
+        error!(?ossl_err);
+        TpmError::MsOapxbcKeyOaepOption
+    })?;
+
+    wrap_key_decrypter
+        .set_rsa_padding(Padding::PKCS1_OAEP)
+        .map_err(|ossl_err| {
+            error!(?ossl_err);
+            TpmError::MsOapxbcKeyOaepOption
+        })?;
+
+    wrap_key_decrypter
+        .set_rsa_mgf1_md(MessageDigest::sha1())
+        .map_err(|ossl_err| {
+            error!(?ossl_err);
+            TpmError::MsOapxbcKeyOaepOption
+        })?;
+
+    wrap_key_decrypter
+        .set_rsa_oaep_md(MessageDigest::sha1())
+        .map_err(|ossl_err| {
+            error!(?ossl_err);
+            TpmError::MsOapxbcKeyOaepOption
+        })?;
+
+    // Rsa oaep will often work on bigger block sizes, so we need a larger buffer and then we
+    // can copy later. First we check the expected length of the decryption.
+    let buf_len = wrap_key_decrypter.decrypt_len(input).map_err(|ossl_err| {
+        error!(?ossl_err);
+        TpmError::MsOapxbcKeyOaepDecipher
+    })?;
+
+    let mut unwrapped_key = Zeroizing::new(vec![0; buf_len]);
+
+    wrap_key_decrypter
+        .decrypt(input, unwrapped_key.as_mut())
+        .map_err(|ossl_err| {
+            error!(?ossl_err);
+            TpmError::MsOapxbcKeyOaepDecipher
+        })?;
+
+    Ok(unwrapped_key)
 }
 
 fn aes_256_gcm_encrypt(

--- a/src/soft.rs
+++ b/src/soft.rs
@@ -700,6 +700,7 @@ impl Tpm for SoftTpm {
     }
 }
 
+#[cfg(feature = "msextensions")]
 fn rsa_oaep_encrypt(
     key: &Rsa<openssl::pkey::Private>,
     key_to_wrap: &[u8],
@@ -759,6 +760,7 @@ fn rsa_oaep_encrypt(
     Ok(wrapped_key)
 }
 
+#[cfg(feature = "msextensions")]
 fn rsa_oaep_decrypt(
     key: &Rsa<openssl::pkey::Private>,
     input: &[u8],

--- a/src/soft.rs
+++ b/src/soft.rs
@@ -1,6 +1,7 @@
 use crate::{
     AuthValue, HmacKey, IdentityKey, KeyAlgorithm, LoadableHmacKey, LoadableIdentityKey,
-    LoadableMachineKey, MachineKey, Tpm, TpmError, AES256GCM_KEY_LEN, HMAC_KEY_LEN,
+    LoadableMachineKey, MachineKey, Tpm, TpmError, AES256GCM_IV_LEN, AES256GCM_KEY_LEN,
+    HMAC_KEY_LEN,
 };
 use zeroize::Zeroizing;
 
@@ -41,7 +42,7 @@ impl Tpm for SoftTpm {
         })?;
 
         // Encrypt it.
-        let mut iv = [0; 16];
+        let mut iv = [0; AES256GCM_IV_LEN];
         rand_bytes(&mut iv).map_err(|ossl_err| {
             error!(?ossl_err);
             TpmError::Entropy
@@ -857,7 +858,7 @@ fn rsa_oaep_decrypt(
     Ok(unwrapped_key)
 }
 
-fn aes_256_gcm_encrypt(
+pub(crate) fn aes_256_gcm_encrypt(
     input: &[u8],
     key: &[u8],
     iv: &[u8],
@@ -896,7 +897,7 @@ fn aes_256_gcm_encrypt(
     Ok((ciphertext, tag))
 }
 
-fn aes_256_gcm_decrypt(
+pub(crate) fn aes_256_gcm_decrypt(
     input: &[u8],
     tag: &[u8],
     key: &[u8],


### PR DESCRIPTION
Add support for MS OAPXBC key management in the soft-tpm, with a view to have this work with HW TPM's. 

## Checklist

- [ x ] This pr contains no AI generated code
- [ x ] cargo fmt has been run
- [ x ] cargo clippy has been run and there's no issues
- [ x ] cargo test has been run and passes
