### PR TITLE
Dmulder/key auth value

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,11 +19,11 @@ hex = "0.4.3"
 openssl = "^0.10.57"
 serde = { version = "^1.0", features = ["derive"] }
 tracing = "^0.1.37"
-# tss-esapi-sys = { version = "0.5.0", optional = true, features = ["generate-bindings"] }
-# tss-esapi = { version = "=8.0.0-alpha", optional = true }
+tss-esapi-sys = { version = "0.5.0", optional = true, features = ["generate-bindings"] }
+tss-esapi = { version = "=8.0.0-alpha", optional = true }
 
-tss-esapi-sys = { path = "../rust-tss-esapi/tss-esapi-sys", optional = true, features = ["generate-bindings"] }
-tss-esapi = { path = "../rust-tss-esapi/tss-esapi", optional = true }
+# tss-esapi-sys = { path = "../rust-tss-esapi/tss-esapi-sys", optional = true, features = ["generate-bindings"] }
+# tss-esapi = { path = "../rust-tss-esapi/tss-esapi", optional = true }
 
 zeroize = "1.6.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,12 @@ hex = "0.4.3"
 openssl = "^0.10.57"
 serde = { version = "^1.0", features = ["derive"] }
 tracing = "^0.1.37"
-tss-esapi-sys = { version = "0.5.0", optional = true, features = ["generate-bindings"] }
-tss-esapi = { version = "=8.0.0-alpha", optional = true }
+# tss-esapi-sys = { version = "0.5.0", optional = true, features = ["generate-bindings"] }
+# tss-esapi = { version = "=8.0.0-alpha", optional = true }
+
+tss-esapi-sys = { path = "../rust-tss-esapi/tss-esapi-sys", optional = true, features = ["generate-bindings"] }
+tss-esapi = { path = "../rust-tss-esapi/tss-esapi", optional = true }
+
 zeroize = "1.6.0"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,7 @@ impl PinValue {
                 TpmError::AuthValueDerivation
             })?;
 
-        let now = std::time::SystemTime::now();
+        // let now = std::time::SystemTime::now();
 
         argon
             .hash_password_into(self.value.as_ref(), salt, auth_key.as_mut())
@@ -105,7 +105,7 @@ impl PinValue {
                 TpmError::AuthValueDerivation
             })?;
 
-        error!(elapsed = ?now.elapsed());
+        // error!(elapsed = ?now.elapsed());
 
         Ok(auth_key)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,7 @@ pub struct PinValue {
     value: Zeroizing<Vec<u8>>,
 }
 
+#[derive(Debug)]
 pub enum TpmPinError {
     TooShort(u8),
     TooLarge(u8),
@@ -912,7 +913,7 @@ mod tests {
 
     #[macro_export]
     macro_rules! test_tpm_identity {
-        ( $tpm:expr, $alg:expr ) => {
+        ( $tpm:expr, $alg:expr, $pin_value:expr ) => {
             use crate::{AuthValue, Tpm};
             use openssl::hash::MessageDigest;
             use openssl::pkey::PKey;
@@ -938,17 +939,15 @@ mod tests {
                 .machine_key_load(&auth_value, &loadable_machine_key)
                 .expect("Unable to load machine key");
 
-            let id_key_pin_value = None;
-
             // from that ctx, create an identity key
             let loadable_id_key = $tpm
-                .identity_key_create(&machine_key, id_key_pin_value, $alg)
+                .identity_key_create(&machine_key, $pin_value.as_ref(), $alg)
                 .expect("Unable to create id key");
 
             trace!(?loadable_id_key);
 
             let id_key = $tpm
-                .identity_key_load(&machine_key, id_key_pin_value, &loadable_id_key)
+                .identity_key_load(&machine_key, $pin_value.as_ref(), &loadable_id_key)
                 .expect("Unable to load id key");
 
             let id_key_public_pem = $tpm

--- a/src/soft.rs
+++ b/src/soft.rs
@@ -1,6 +1,6 @@
 use crate::{
     AuthValue, HmacKey, IdentityKey, KeyAlgorithm, LoadableHmacKey, LoadableIdentityKey,
-    LoadableMachineKey, MachineKey, Tpm, TpmError, AES256GCM_IV_LEN, AES256GCM_KEY_LEN,
+    LoadableMachineKey, MachineKey, PinValue, Tpm, TpmError, AES256GCM_IV_LEN, AES256GCM_KEY_LEN,
     HMAC_KEY_LEN,
 };
 use zeroize::Zeroizing;
@@ -147,7 +147,7 @@ impl Tpm for SoftTpm {
     fn identity_key_create(
         &mut self,
         mk: &MachineKey,
-        auth_value: Option<&AuthValue>,
+        auth_value: Option<&PinValue>,
         algorithm: KeyAlgorithm,
     ) -> Result<LoadableIdentityKey, TpmError> {
         if auth_value.is_some() {
@@ -228,7 +228,7 @@ impl Tpm for SoftTpm {
     fn identity_key_load(
         &mut self,
         mk: &MachineKey,
-        auth_value: Option<&AuthValue>,
+        auth_value: Option<&PinValue>,
         loadable_key: &LoadableIdentityKey,
     ) -> Result<IdentityKey, TpmError> {
         if auth_value.is_some() {
@@ -465,7 +465,7 @@ impl Tpm for SoftTpm {
     fn identity_key_certificate_request(
         &mut self,
         mk: &MachineKey,
-        auth_value: Option<&AuthValue>,
+        auth_value: Option<&PinValue>,
         loadable_key: &LoadableIdentityKey,
         cn: &str,
     ) -> Result<Vec<u8>, TpmError> {
@@ -525,7 +525,7 @@ impl Tpm for SoftTpm {
     fn identity_key_associate_certificate(
         &mut self,
         mk: &MachineKey,
-        auth_value: Option<&AuthValue>,
+        auth_value: Option<&PinValue>,
         loadable_key: &LoadableIdentityKey,
         certificate_der: &[u8],
     ) -> Result<LoadableIdentityKey, TpmError> {

--- a/src/soft.rs
+++ b/src/soft.rs
@@ -954,6 +954,7 @@ pub(crate) fn aes_256_gcm_decrypt(
 #[cfg(test)]
 mod tests {
     use super::{aes_256_gcm_decrypt, aes_256_gcm_encrypt, KeyAlgorithm, SoftTpm};
+    use crate::PinValue;
     use tracing::trace;
 
     #[test]
@@ -1001,19 +1002,43 @@ mod tests {
     }
 
     #[test]
-    fn soft_identity_ecdsa256_hw_bound() {
+    fn soft_identity_ecdsa256() {
         // Create the Hsm.
         let mut hsm = SoftTpm::new();
 
-        crate::test_tpm_identity!(hsm, KeyAlgorithm::Ecdsa256);
+        let pin_value = None;
+
+        crate::test_tpm_identity!(hsm, KeyAlgorithm::Ecdsa256, pin_value);
     }
 
     #[test]
-    fn soft_identity_rsa2048_hw_bound() {
+    fn soft_identity_rsa2048() {
         // Create the Hsm.
         let mut hsm = SoftTpm::new();
 
-        crate::test_tpm_identity!(hsm, KeyAlgorithm::Rsa2048);
+        let pin_value = None;
+
+        crate::test_tpm_identity!(hsm, KeyAlgorithm::Rsa2048, pin_value);
+    }
+
+    #[test]
+    fn soft_identity_ecdsa256_pin() {
+        // Create the Hsm.
+        let mut hsm = SoftTpm::new();
+
+        let pin_value = Some(PinValue::new("12345678").expect("Invalid Pin"));
+
+        crate::test_tpm_identity!(hsm, KeyAlgorithm::Ecdsa256, pin_value);
+    }
+
+    #[test]
+    fn soft_identity_rsa2048_pin() {
+        // Create the Hsm.
+        let mut hsm = SoftTpm::new();
+
+        let pin_value = Some(PinValue::new("12345678").expect("Invalid Pin"));
+
+        crate::test_tpm_identity!(hsm, KeyAlgorithm::Rsa2048, pin_value);
     }
 
     #[test]

--- a/src/tpm.rs
+++ b/src/tpm.rs
@@ -23,8 +23,8 @@ use tss_esapi::structures::{
 use tss_esapi::Context;
 use tss_esapi::TctiNameConf;
 
-use tss_esapi::interface_types::reserved_handles::Hierarchy;
-// use tss_esapi::interface_types::resource_handles::Hierarchy;
+// use tss_esapi::interface_types::reserved_handles::Hierarchy;
+use tss_esapi::interface_types::resource_handles::Hierarchy;
 
 use tss_esapi::constants::tss::TPM2_RH_NULL;
 use tss_esapi::constants::tss::TPM2_ST_HASHCHECK;
@@ -38,8 +38,8 @@ use tss_esapi::handles::ObjectHandle;
 
 pub use tss_esapi::handles::KeyHandle;
 pub use tss_esapi::structures::{Auth, Private, Public};
-// pub use tss_esapi::utils::TpmsContext;
-pub use tss_esapi::structures::SavedTpmContext as TpmsContext;
+pub use tss_esapi::utils::TpmsContext;
+// pub use tss_esapi::structures::SavedTpmContext as TpmsContext;
 
 #[cfg(feature = "msextensions")]
 use crate::soft::{aes_256_gcm_decrypt, aes_256_gcm_encrypt};


### PR DESCRIPTION
Refers #32 - Fix PIN Value support for identity keys. This works on the TPM with it's native lockout features, and soft with argon2id derivation hmaced (peppered) to the machine key.

## Checklist

- [ x ] This pr contains no AI generated code
- [ x ] cargo fmt has been run
- [ x ] cargo clippy has been run and there's no issues
- [ x ] cargo test has been run and passes
