### PR TITLE
20250424 pin updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ tpm = ["dep:tss-esapi", "dep:tss-esapi-sys"]
 # crypto-glue = { path = "../crypto-glue" }
 
 [dependencies]
-crypto-glue = "^0.1.3"
+crypto-glue = "^0.1.4"
 serde = { version = "^1.0", features = ["derive"] }
 tracing = "^0.1.37"
 tss-esapi-sys = { version = "0.5.0", optional = true, features = [

--- a/src/pin.rs
+++ b/src/pin.rs
@@ -2,23 +2,12 @@ use crate::error::TpmError;
 use crypto_glue::{
     aes256::{self, Aes256Key},
     argon2,
+    hmac_s256::HmacSha256Output,
     zeroize::Zeroizing,
 };
 use tracing::error;
 
 pub(crate) const TPM_PIN_MIN_LEN: u8 = 6;
-// TPM's limit the max pin based on algorithm max bytes per the
-// size of the largest hash. This means pins max out at 32 bytes
-// as that's the size of sha256 output.
-pub(crate) const TPM_PIN_MAX_LEN: u8 = 32;
-
-// These can't be changed else it will break key derivation.
-//
-// To increase these parameters we need to introduce a new pin
-// derive function that has the new values.
-const ARGON2ID_MEMORY: u32 = 32_768;
-const ARGON2ID_TIME: u32 = 1;
-const ARGON2ID_PARALLEL: u32 = 1;
 
 pub struct PinValue {
     value: Zeroizing<Vec<u8>>,
@@ -27,15 +16,12 @@ pub struct PinValue {
 #[derive(Debug)]
 pub enum TpmPinError {
     TooShort(u8),
-    TooLarge(u8),
 }
 
 impl PinValue {
     pub fn new(input: &str) -> Result<Self, TpmPinError> {
         if input.len() < TPM_PIN_MIN_LEN as usize {
             return Err(TpmPinError::TooShort(TPM_PIN_MIN_LEN));
-        } else if input.len() > TPM_PIN_MAX_LEN as usize {
-            return Err(TpmPinError::TooLarge(TPM_PIN_MAX_LEN));
         }
 
         Ok(PinValue {
@@ -49,12 +35,15 @@ impl PinValue {
 
     /// Derive an AES256GCM Key from this PIN. This is used by the soft-tpm exclusively.
     pub(crate) fn derive_aes_256(&self, parent_key: &Aes256Key) -> Result<Aes256Key, TpmError> {
-        use argon2::{Algorithm, Argon2, Params, Version};
+        // These can't be changed else it will break key derivation.
+        //
+        // To increase these parameters we need to introduce a new pin
+        // derive function that has the new values.
+        const ARGON2ID_MEMORY: u32 = 32_768;
+        const ARGON2ID_TIME: u32 = 1;
+        const ARGON2ID_PARALLEL: u32 = 1;
 
-        // Want at least 8 bytes salt, 16 bytes pw input.
-        if parent_key.len() < 24 {
-            return Err(TpmError::AuthValueTooShort);
-        }
+        use argon2::{Algorithm, Argon2, Params, Version};
 
         let mut auth_key = Aes256Key::default();
 
@@ -83,6 +72,60 @@ impl PinValue {
 
         argon
             .hash_password_into(self.value.as_ref(), salt, auth_key.as_mut())
+            .map_err(|argon_err| {
+                error!(?argon_err);
+                TpmError::AuthValueDerivation
+            })?;
+
+        // error!(elapsed = ?now.elapsed());
+
+        Ok(auth_key)
+    }
+
+    /// Derive an AES256GCM Key from this PIN. This is used by the soft-tpm exclusively.
+    pub(crate) fn derive_hmac_s256_aes_256(
+        &self,
+        hmac_output: HmacSha256Output,
+        parent_key: &Aes256Key,
+    ) -> Result<Aes256Key, TpmError> {
+        // These can't be changed else it will break key derivation.
+        //
+        // To increase these parameters we need to introduce a new pin
+        // derive function that has the new values.
+        const ARGON2ID_MEMORY: u32 = 32_768;
+        const ARGON2ID_TIME: u32 = 1;
+        const ARGON2ID_PARALLEL: u32 = 1;
+
+        use argon2::{Algorithm, Argon2, Params, Version};
+
+        let mut auth_key = Aes256Key::default();
+
+        // This can't be changed else it will break key derivation for users.
+        let argon2id_params = Params::new(
+            ARGON2ID_MEMORY,
+            ARGON2ID_TIME,
+            ARGON2ID_PARALLEL,
+            Some(aes256::key_size()),
+        )
+        .map_err(|argon_err| {
+            error!(?argon_err);
+            TpmError::AuthValueDerivation
+        })?;
+
+        let salt = hmac_output.into_bytes();
+        let pepper = parent_key.as_slice();
+
+        let argon =
+            Argon2::new_with_secret(pepper, Algorithm::Argon2id, Version::V0x13, argon2id_params)
+                .map_err(|argon_err| {
+                error!(?argon_err);
+                TpmError::AuthValueDerivation
+            })?;
+
+        // let now = std::time::SystemTime::now();
+
+        argon
+            .hash_password_into(self.value.as_ref(), salt.as_slice(), auth_key.as_mut())
             .map_err(|argon_err| {
                 error!(?argon_err);
                 TpmError::AuthValueDerivation

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -47,19 +47,6 @@ pub trait Tpm {
         lsk: &LoadableStorageKey,
     ) -> Result<StorageKey, TpmError>;
 
-    fn storage_key_create_pin(
-        &mut self,
-        parent_key: &StorageKey,
-        pin: &PinValue,
-    ) -> Result<LoadableStorageKey, TpmError>;
-
-    fn storage_key_load_pin(
-        &mut self,
-        parent_key: &StorageKey,
-        pin: &PinValue,
-        lsk: &LoadableStorageKey,
-    ) -> Result<StorageKey, TpmError>;
-
     fn seal_data(
         &mut self,
         key: &StorageKey,
@@ -90,6 +77,23 @@ pub trait TpmHmacS256 {
         hmac_key: &HmacS256Key,
         data: &[u8],
     ) -> Result<HmacSha256Output, TpmError>;
+}
+
+pub trait TpmPinHmacS256: Tpm + TpmHmacS256 {
+    fn storage_key_create_pin_hmac_s256(
+        &mut self,
+        parent_key: &StorageKey,
+        hmac_key: &HmacS256Key,
+        pin: &PinValue,
+    ) -> Result<LoadableStorageKey, TpmError>;
+
+    fn storage_key_load_pin_hmac_s256(
+        &mut self,
+        parent_key: &StorageKey,
+        hmac_key: &HmacS256Key,
+        pin: &PinValue,
+        lsk: &LoadableStorageKey,
+    ) -> Result<StorageKey, TpmError>;
 }
 
 pub struct TpmES256Keypair {

--- a/src/provider/tss.rs
+++ b/src/provider/tss.rs
@@ -1285,8 +1285,8 @@ impl TpmRS256 for TssTpm {
 
     fn rs256_import(
         &mut self,
-        parent_key: &StorageKey,
-        private_key: RS256PrivateKey,
+        _parent_key: &StorageKey,
+        _private_key: RS256PrivateKey,
     ) -> Result<LoadableRS256Key, TpmError> {
         Err(TpmError::TssRs256ImportNotSupported)
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -11,7 +11,7 @@ use crypto_glue::spki::der::Encode;
 use crypto_glue::spki::DynSignatureAlgorithmIdentifier;
 use crypto_glue::traits::*;
 use crypto_glue::x509;
-use crypto_glue::x509::Builder;
+use crypto_glue::x509::{Builder, X509Display};
 use std::str::FromStr;
 use std::time::{Duration, SystemTime};
 use tracing::trace;
@@ -212,11 +212,7 @@ pub(crate) fn test_tpm_ecdsa_p256<T: Tpm + TpmES256>(mut tpm_a: T) {
 
     let cert = cert_builder.assemble(signature).unwrap();
 
-    let mut out = String::new();
-
-    x509::display::cert_to_string_pretty(&cert, &mut out).unwrap();
-
-    println!("{}", out);
+    println!("{}", X509Display::from(&cert));
 
     // Check the public keys are the same. Fuck me the rust crypto apis don't
     // make this easy at all .....
@@ -343,11 +339,7 @@ pub(crate) fn test_tpm_rs256<T: Tpm + TpmRS256>(mut tpm_a: T) {
 
     let cert = cert_builder.assemble(signature).unwrap();
 
-    let mut out = String::new();
-
-    x509::display::cert_to_string_pretty(&cert, &mut out).unwrap();
-
-    println!("{}", out);
+    println!("{}", X509Display::from(&cert));
 
     // Check the public keys are the same. Fuck me the rust crypto apis don't
     // make this easy at all .....


### PR DESCRIPTION
Improve pin handling such that an associated hmac key is required. This mitigates issues with pin maximum length restrictions on TPM's, and further hardens against bruteforce of PIN's on the TPM since HMAC is a proven construction that is difficult to attack. 

## Checklist

- [ ] This pr contains no AI generated code
- [ ] cargo fmt has been run
- [ ] cargo clippy has been run and there's no issues
- [ ] cargo test has been run and passes
