### PR TITLE
Improve trait handling and dereferencing.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kanidm-hsm-crypto"
 description = "A library for easily interacting with a HSM or TPM"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 license = "MPL-2.0"
 homepage = "https://github.com/kanidm/hsm-crypto/"

--- a/src/provider/dynt.rs
+++ b/src/provider/dynt.rs
@@ -32,6 +32,22 @@ where
     }
 }
 
+impl std::ops::Deref for BoxedDynTpm {
+    type Target = dyn TpmFullSupport;
+
+    // Required method
+    fn deref(&self) -> &Self::Target {
+        self.0.as_ref()
+    }
+}
+
+impl std::ops::DerefMut for BoxedDynTpm {
+    // Required method
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.0.as_mut()
+    }
+}
+
 impl Tpm for BoxedDynTpm {
     fn root_storage_key_create(
         &mut self,

--- a/src/provider/soft.rs
+++ b/src/provider/soft.rs
@@ -1,7 +1,7 @@
 use crate::authvalue::AuthValue;
 use crate::error::TpmError;
 use crate::pin::PinValue;
-use crate::provider::{Tpm, TpmES256, TpmFullSupport, TpmHmacS256, TpmMsExtensions, TpmRS256};
+use crate::provider::{Tpm, TpmES256, TpmHmacS256, TpmMsExtensions, TpmRS256};
 use crate::structures::{
     ES256Key, HmacS256Key, LoadableES256Key, LoadableHmacS256Key, LoadableRS256Key,
     LoadableStorageKey, RS256Key, SealedData, StorageKey,
@@ -27,8 +27,6 @@ use tracing::error;
 
 #[derive(Default)]
 pub struct SoftTpm {}
-
-impl TpmFullSupport for SoftTpm {}
 
 impl Tpm for SoftTpm {
     // create a root-storage-key


### PR DESCRIPTION
During the upgrade of hsm-crypto in kanidm, found a few places where I could make trait handling nicer. 

## Checklist

- [x] This pr contains no AI generated code
- [x] cargo fmt has been run
- [x] cargo clippy has been run and there's no issues
- [x] cargo test has been run and passes
